### PR TITLE
fix: disable shore-weighing button when no fish were caught

### DIFF
--- a/src/components/containers/FishingActions.tsx
+++ b/src/components/containers/FishingActions.tsx
@@ -37,12 +37,16 @@ const FishingActions = ({ fishing }: FishingActionsProps) => {
 
   const loading = fishingWeightsLoading;
 
-  const weightOnBoatExist =
-    !!fishingWeights?.preliminary && !!Object.keys(fishingWeights.preliminary).length;
+  const hasFishAmount = (record?: Record<string, unknown>) =>
+    !!record && Object.values(record).some((amount) => Number(amount) > 0);
 
-  const weightOnShoreExist = !!fishingWeights?.total && !!Object.keys(fishingWeights.total).length;
+  const weightOnBoatExist = hasFishAmount(fishingWeights?.preliminary);
+
+  const weightOnShoreExist = hasFishAmount(fishingWeights?.total);
 
   const isDisabled = locationType !== LocationType.INLAND_WATERS && weightOnShoreExist;
+
+  const shoreWeighingDisabled = isDisabled || !weightOnBoatExist;
 
   return loading ? (
     <LoaderComponent />
@@ -68,7 +72,7 @@ const FishingActions = ({ fishing }: FishingActionsProps) => {
           title="Žuvies svoris</br>krante"
           subtitle="Pasverkite bendrą svorį"
           buttonLabel="Sverti"
-          isDisabled={isDisabled}
+          isDisabled={shoreWeighingDisabled}
           onClick={() => {
             navigate(slugs.fishingWeight);
           }}


### PR DESCRIPTION
## Problem

When an angler checks tools but catches nothing, the preliminary weights record empty / all-zero \`data\`. The "Sverti krante" (weigh on shore) button stays enabled, sending the angler to a weighing screen with nothing to weigh, and previously the "Baigti" (end) button blocked them too.

## Fix

Tighten the on-boat / on-shore checks: a weighing only "exists" if at least one fish amount is greater than zero. Object-keys-only check would treat \`{}\` as valid and missed all-zero entries.

\`\`\`ts
const hasFishAmount = (record?: Record<string, unknown>) =>
  !!record && Object.values(record).some((amount) => Number(amount) > 0);

const weightOnBoatExist = hasFishAmount(fishingWeights?.preliminary);
const weightOnShoreExist = hasFishAmount(fishingWeights?.total);
\`\`\`

The "Sverti" button is also disabled when there is no preliminary catch:

\`\`\`ts
const shoreWeighingDisabled = isDisabled || !weightOnBoatExist;
\`\`\`

The "Baigti" button already uses \`weightOnBoatExist\`, so updating its semantics also unblocks ending the trip when all preliminary amounts are zero — that pairs with backend PR https://github.com/AplinkosMinisterija/biip-zvejyba-api/pull/104.

## Test plan

- [ ] No preliminary weights → "Sverti" disabled, "Baigti" enabled
- [ ] Preliminary all zero (\`{1: 0, 2: 0}\`) → "Sverti" disabled, "Baigti" enabled
- [ ] Preliminary has fish (e.g. \`{1: 1.5}\`), no shore total → "Sverti" enabled, "Baigti" disabled
- [ ] Preliminary has fish + shore total submitted → "Sverti" disabled (already weighed), "Baigti" enabled
- [ ] Inland waters trip → behavior unchanged (location type bypass still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)