### PR TITLE
feat: shore-only weighing for polders (match inland-waters flow)

### DIFF
--- a/src/components/containers/FishingActions.tsx
+++ b/src/components/containers/FishingActions.tsx
@@ -2,7 +2,13 @@ import { useContext } from 'react';
 import { useQuery } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
-import { Fishing, FishingTypeRoute, LocationType, PopupContentType, slugs } from '../../utils';
+import {
+  Fishing,
+  FishingTypeRoute,
+  isShoreOnlyWeighing,
+  PopupContentType,
+  slugs,
+} from '../../utils';
 import api from '../../utils/api';
 import { Variant } from '../buttons/FishingLocationButton';
 import LargeButton from '../buttons/LargeButton';
@@ -44,7 +50,7 @@ const FishingActions = ({ fishing }: FishingActionsProps) => {
 
   const weightOnShoreExist = hasFishAmount(fishingWeights?.total);
 
-  const isDisabled = locationType !== LocationType.INLAND_WATERS && weightOnShoreExist;
+  const isDisabled = !isShoreOnlyWeighing(locationType) && weightOnShoreExist;
 
   const shoreWeighingDisabled = isDisabled || !weightOnBoatExist;
 
@@ -56,7 +62,7 @@ const FishingActions = ({ fishing }: FishingActionsProps) => {
         <LargeButton
           variant={Variant.FLORAL_WHITE}
           title={
-            locationType === LocationType.INLAND_WATERS
+            isShoreOnlyWeighing(locationType)
               ? 'Statykite arba</br>ištraukite įrankius'
               : 'Tikrinkite arba</br>statykite įrankius'
           }
@@ -84,7 +90,7 @@ const FishingActions = ({ fishing }: FishingActionsProps) => {
           buttonLabel="Baigti"
           onClick={() => showPopup({ type: PopupContentType.END_FISHING })}
           isDisabled={
-            locationType !== LocationType.INLAND_WATERS && weightOnBoatExist && !weightOnShoreExist
+            !isShoreOnlyWeighing(locationType) && weightOnBoatExist && !weightOnShoreExist
           }
         />
       </Container>

--- a/src/components/popups/ToolGroupAction.tsx
+++ b/src/components/popups/ToolGroupAction.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import {
   handleErrorToast,
   handleErrorToastFromServer,
-  LocationType,
+  isShoreOnlyWeighing,
   PopupContentType,
   useGeolocation,
 } from '../../utils';
@@ -90,7 +90,7 @@ const ToolGroupAction = ({ onClose, content }: any) => {
           <LoaderComponent />
         ) : (
           <>
-            {currentFishing?.type !== LocationType.INLAND_WATERS && showWeightButtons && (
+            {!isShoreOnlyWeighing(currentFishing?.type) && showWeightButtons && (
               <>
                 <MenuButton
                   label="Sverti žuvį laive "

--- a/src/pages/FishingWeight.tsx
+++ b/src/pages/FishingWeight.tsx
@@ -10,7 +10,7 @@ import { PopupContext, PopupContextProps } from '../components/providers/PopupPr
 import {
   FishingWeighType,
   handleErrorToast,
-  LocationType,
+  isShoreOnlyWeighing,
   PopupContentType,
   useCurrentFishing,
   useFishingWeightMutation,
@@ -24,7 +24,7 @@ const FishingWeight = () => {
   const [type, setType] = useState<FishingWeighType>(FishingWeighType.CAUGHT);
   const [isSwitching, setIsSwitching] = useState(false);
   const { data: currentFishing, isLoading: currentFishingLoading } = useCurrentFishing();
-  const showSwitch = currentFishing?.type !== LocationType.INLAND_WATERS;
+  const showSwitch = !isShoreOnlyWeighing(currentFishing?.type);
   const { fishTypes, fishTypesLoading } = useFishTypes();
   const { fishingWeights, fishingWeightsLoading } = useFishWeights();
   const { fishingWeightLoading, fishingWeightMutation } = useFishingWeightMutation();
@@ -37,7 +37,7 @@ const FishingWeight = () => {
 
   const caughtFishData = fishingWeights?.total || fishingWeights?.preliminary || {};
   const initialValues = (
-    currentFishing?.type === LocationType.INLAND_WATERS || type !== FishingWeighType.CAUGHT
+    isShoreOnlyWeighing(currentFishing?.type) || type !== FishingWeighType.CAUGHT
       ? fishTypes.map((fishType) => {
           const amount = (fishingWeights?.total || fishingWeights?.preliminary)?.[fishType.id];
           return {

--- a/src/utils/functions.ts
+++ b/src/utils/functions.ts
@@ -3,7 +3,7 @@ import { toZonedTime } from 'date-fns-tz';
 import { toast } from 'react-toastify';
 import Cookies from 'universal-cookie';
 import api from './api';
-import { ToolTypeType } from './constants';
+import { LocationType, ToolTypeType } from './constants';
 import { validationTexts } from './texts';
 import { Profile, ProfileId, ReactQueryError, ResponseProps, ToolsGroup } from './types';
 const cookies = new Cookies();
@@ -241,3 +241,8 @@ export const formatDateTo = (date: Date) => {
 export const formatDateFrom = (date: Date) => {
   return toZonedTime(startOfDay(new Date(date)), 'Europe/Vilnius');
 };
+
+// Polders and inland-water fishings only weigh fish on shore — no on-boat
+// preliminary step. Used to gate the boat-weighing UI consistently.
+export const isShoreOnlyWeighing = (type?: LocationType) =>
+  type === LocationType.INLAND_WATERS || type === LocationType.POLDERS;


### PR DESCRIPTION
## Summary

In polders the angler weighs fish **only on shore** — there is no on-boat preliminary weighing step. Inland-water fishings already work this way, so introduce a small `isShoreOnlyWeighing(type)` helper that returns `true` for both `INLAND_WATERS` and `POLDERS`, and wrap the existing INLAND_WATERS branches with it.

Behaviour for POLDERS now mirrors INLAND_WATERS:

- **ToolGroupAction** popup hides the "Sverti žuvį laive" button — no per-tool boat weighing
- **FishingActions** tile reads "Statykite arba ištraukite įrankius" (no "tikrinkite" wording, since there's no checking step)
- "Pastatyti įrankį" no longer disables once a shore weight exists, and "Baigti žvejybą" no longer waits on a shore weight that followed a boat weight
- **FishingWeight** page hides the boat/shore switch and treats totals as the only set of values

No backend changes — the on-boat / on-shore distinction is purely a client-side concern. The weight-event records on the API are type-agnostic.

## Test plan

- [ ] Start a polder fishing, build a tool, click the tool: only "Sugrąžinti į sandėlį" shows (no "Sverti žuvį laive")
- [ ] FishingActions tile in polder fishing: title is "Statykite arba ištraukite įrankius"
- [ ] FishingWeight page in polder fishing: no boat/shore switch
- [ ] Inland-waters fishing flow is unchanged (regression check)
- [ ] Estuary (Kuršių mariose) flow is unchanged: "Sverti žuvį laive" still shown, switch still shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)