### PR TITLE
fix: stop the screen from re-fetching on every GPS tick on a moving boat

### DIFF
--- a/src/components/other/FishRow.tsx
+++ b/src/components/other/FishRow.tsx
@@ -20,8 +20,6 @@ const FishRow = React.memo(({ onChange, fish, index }: FishRowProp) => {
 
   const { label, photo, amount, preliminaryAmount } = fish;
 
-  console.log(preliminaryAmount, 'preliminaryAmountpreliminaryAmount');
-
   return (
     <Row>
       <ImageContainer>

--- a/src/components/providers/GeolocationProvider.tsx
+++ b/src/components/providers/GeolocationProvider.tsx
@@ -12,11 +12,31 @@ export interface GeolocationContextProps {
   refresh: () => void;
 }
 
-const POSITION_OPTIONS: PositionOptions = {
+// Continuous high-accuracy watch — used once the angler is on the water.
+const WATCH_OPTIONS: PositionOptions = {
   enableHighAccuracy: true,
   timeout: 20000,
   maximumAge: 25000,
 };
+
+// Initial fast fix using whatever the device has handy (cell / wifi cache).
+// Boat-side GPS warm-ups can take 10s+, which is why ~50% of users were
+// hitting the timeout error toast on first load.
+const INITIAL_FIX_OPTIONS: PositionOptions = {
+  enableHighAccuracy: false,
+  timeout: 8000,
+  maximumAge: 60000,
+};
+
+// On a moving boat the GPS can fire several times per second with
+// sub-meter drift. Without a threshold every tick produced a new
+// coordinates object → React Query refetched the location lookup,
+// downstream components re-rendered, and the screen "shook".
+// 0.0005° ≈ 50 m at Lithuania's latitude — fine-grained enough for a
+// build-event geom yet coarse enough to keep fishing-tools queries
+// from firing on every GPS tick (a polder / bar / lake spans hundreds
+// of meters, so 50 m is well within the same bucket).
+const MIN_COORDINATE_DELTA = 0.0005;
 
 export const GeolocationContext = createContext<GeolocationContextProps>({
   coordinates: null,
@@ -47,7 +67,14 @@ export const GeolocationProvider: React.FC<{ children: React.ReactNode }> = ({ c
         x: position.coords.longitude,
         y: position.coords.latitude,
       };
-      if (prev && prev.x === next.x && prev.y === next.y) return prev;
+      if (
+        prev &&
+        Math.abs(prev.x - next.x) < MIN_COORDINATE_DELTA &&
+        Math.abs(prev.y - next.y) < MIN_COORDINATE_DELTA
+      ) {
+        // Same reference → consumers' query keys stay equal, no refetch.
+        return prev;
+      }
       return next;
     });
     finishInitialResolve();
@@ -61,11 +88,10 @@ export const GeolocationProvider: React.FC<{ children: React.ReactNode }> = ({ c
         navigator.geolocation.clearWatch(watchIdRef.current);
         watchIdRef.current = null;
       }
-    } else if (!isWatch && err.code === 2) {
-      handleErrorToast('Nepavyko nustatyti jūsų vietos.');
-    } else if (!isWatch && err.code === 3) {
-      handleErrorToast('Baigėsi vietos nustatymo laukimo laikas. Bandykite dar kartą.');
     }
+    // Silent on unavailable / timeout — the continuous watch is running and
+    // will recover on its own. Surfacing a toast for every transient GPS
+    // hiccup spammed users on a moving boat.
 
     finishInitialResolve();
   };
@@ -76,7 +102,7 @@ export const GeolocationProvider: React.FC<{ children: React.ReactNode }> = ({ c
     watchIdRef.current = navigator.geolocation.watchPosition(
       applyPosition,
       (err) => handleGeolocationError(err, true),
-      POSITION_OPTIONS,
+      WATCH_OPTIONS,
     );
   };
 
@@ -99,13 +125,16 @@ export const GeolocationProvider: React.FC<{ children: React.ReactNode }> = ({ c
       handleGeolocationToast(true);
     }
 
+    // Start the continuous watch immediately so we don't depend on a single
+    // getCurrentPosition succeeding — boat GPS often takes 10s+ for the first
+    // fix, and the previous flow left the user with no coordinates at all if
+    // that initial call timed out.
+    startWatch();
+
     navigator.geolocation.getCurrentPosition(
-      (position) => {
-        applyPosition(position);
-        startWatch();
-      },
+      applyPosition,
       (err) => handleGeolocationError(err, false),
-      POSITION_OPTIONS,
+      INITIAL_FIX_OPTIONS,
     );
   }, []);
 

--- a/src/pages/FishingWeight.tsx
+++ b/src/pages/FishingWeight.tsx
@@ -56,8 +56,6 @@ const FishingWeight = () => {
         })
   ).sort((a, b) => (Number(b.preliminaryAmount) || 0) - (Number(a.preliminaryAmount) || 0));
 
-  console.log(initialValues, 'initialValues');
-
   const mapWeights = (values: any) => {
     return values.reduce((obj: any, curr: any) => {
       if (curr.amount !== '' && curr.amount != null) {


### PR DESCRIPTION
## Summary

Two boat-side complaints traced back to the same place — `GeolocationProvider`:

1. _"trūkinėja ir kiekvieną sekundę naujina duomenis ir dreba ekranas"_ — the screen shook and re-fetched while moving.
2. _"geolocationas mėgsta timeoutinti pakankamai dažnai 50%"_ — initial location calls timed out on roughly half of loads.

### What changed

- **50 m threshold** in `applyPosition`. Every GPS tick used to return a new `coordinates` object — downstream `useQuery` keys (`['location', fishingId, x, y]`) changed and the location lookup re-fetched on every drift. With `MIN_COORDINATE_DELTA = 0.0005°` (~50 m at LT latitude) the same reference is returned for sub-50 m moves, so consumers' query keys stay stable. 50 m is well within the same fishing bucket (a polder / bar / lake spans hundreds of meters).
- **Watch starts immediately**, not after `getCurrentPosition` succeeds. The old flow left users with _no_ coordinates if the initial 20 s call timed out.
- **Faster initial fix**: `getCurrentPosition` runs with `enableHighAccuracy: false, timeout: 8000, maximumAge: 60000` — typically resolves in <5 s using cell/wifi cache. The high-accuracy watch takes over once GPS warms up.
- **Silent on transient GPS errors**. Only permission-denied still surfaces a toast; timeouts and "position unavailable" are recoverable by the watch.

Also drops two `console.log` debug leftovers (`FishRow.preliminaryAmount`, `FishingWeight.initialValues`) that fired on every render.

No backend changes — this is entirely client-side.

## Test plan

- [ ] On a moving phone (or with simulated geolocation in DevTools): the FishingTools page no longer re-fetches `getLocation` on every drift; it only refetches when you've moved ≥50 m
- [ ] First load: no "Baigėsi vietos nustatymo laukimo laikas" / "Nepavyko nustatyti jūsų vietos" toasts on transient timeouts
- [ ] Permission-denied still shows the existing toast
- [ ] Build event / shore-weight submissions still capture the current coordinates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)