### PR TITLE
Remove unused lt-codes dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "date-fns-tz": "^3.2.0",
     "formik": "^2.4.5",
     "lodash": "^4.17.21",
-    "lt-codes": "ambrazasp/lt-codes",
     "react": "^18.2.0",
     "react-datepicker": "^4.21.0",
     "react-div-100vh": "^0.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3655,12 +3655,6 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-lt-codes@ambrazasp/lt-codes:
-  version "1.0.0"
-  resolved "https://codeload.github.com/ambrazasp/lt-codes/tar.gz/a3dd47207f1f1a8cc94ecd300b59c0af189351bf"
-  dependencies:
-    moment "^2.29.4"
-
 magic-string@^0.25.0, magic-string@^0.25.7:
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.9.tgz#de7f9faf91ef8a1c91d02c2e5314c8277dbcdd1c"
@@ -3766,11 +3760,6 @@ minimist@^1.2.6, minimist@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
-
-moment@^2.29.4:
-  version "2.29.4"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
-  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
 
 ms@2.1.2:
   version "2.1.2"


### PR DESCRIPTION
## Kontekstas

\`lt-codes\` paketas \`package.json\`'e deklaruotas, bet **niekur \`src/\`'e neimport'inamas** ir niekur nenaudojamas. Patvirtinta \`grep\`'u:

\`\`\`
$ grep -rn "from 'lt-codes'\|require('lt-codes')\|companyCode" src
(nieko)
\`\`\`

Asmens kodo validacija \`src/utils/validations.ts\` įgyvendinta kaip ilgio tikrinimas (\`value.length === 11\`), ne per \`personalCode.validate\`. Taigi paketas — dead dependency.

## Pakeitimai

\`package.json\` — pašalinta \`"lt-codes": "ambrazasp/lt-codes"\`.

\`yarn.lock\` — pašalintas \`lt-codes\` įrašas ir nebereikalingas tranzitinis \`moment\`.

## Kontekstas: kodėl būtent dabar

Aplinkos ministerijoje vyksta \`lt-codes\` migracija į AM-kontroliuojamą fork'ą (\`AplinkosMinisterija/lt-codes#v1.1.2\`). Užuot tampyti dead dep'ą per migraciją, švariau jį iš viso išmesti.

## Test plan

- [ ] \`yarn install\` — install'inasi švariai be \`lt-codes\`.
- [ ] \`yarn build\` praeina.
- [ ] Asmens kodo validacija formoje veikia kaip iki šiol (logika nepakeista).

🤖 Generated with [Claude Code](https://claude.com/claude-code)