### PR TITLE
fix: stop the location query from re-firing on every GPS tick

### DIFF
--- a/src/pages/FishingToolsEstuary.tsx
+++ b/src/pages/FishingToolsEstuary.tsx
@@ -31,7 +31,12 @@ const FishingToolsEstuary = () => {
     isLoading: locationLoading,
     refetch,
   } = useQuery({
-    queryKey: ['location', currentFishing?.id, coordinates?.x, coordinates?.y],
+    // Coordinates intentionally NOT in the queryKey — a moving boat would
+    // otherwise re-fire this query on every GPS tick and put the page back
+    // into the fetching state, blocking tool placement. The queryFn closure
+    // still uses the latest `coordinates` value, and the user can force a
+    // re-detect via the "Atnaujinti lokaciją" button (`refetch`).
+    queryKey: ['location', currentFishing?.id],
     queryFn: () => {
       return api.getLocation({
         query: JSON.stringify({

--- a/src/pages/FishingToolsInlandWaters.tsx
+++ b/src/pages/FishingToolsInlandWaters.tsx
@@ -32,7 +32,12 @@ const FishingTools = () => {
     isFetching: locationLoading,
     refetch,
   } = useQuery({
-    queryKey: ['location', currentFishing?.id, coordinates?.x, coordinates?.y],
+    // Coordinates intentionally NOT in the queryKey — a moving boat would
+    // otherwise re-fire this query on every GPS tick and put the page back
+    // into the fetching state, blocking tool placement. The queryFn closure
+    // still uses the latest `coordinates` value, and the user can force a
+    // re-detect via the "Atnaujinti lokaciją" button (`refetch`).
+    queryKey: ['location', currentFishing?.id],
     queryFn: () => {
       return api.getLocation({
         query: JSON.stringify({

--- a/src/pages/FishingToolsPolders.tsx
+++ b/src/pages/FishingToolsPolders.tsx
@@ -32,7 +32,12 @@ const FishingTools = () => {
     isFetching: locationLoading,
     refetch,
   } = useQuery({
-    queryKey: ['location', currentFishing?.id, coordinates?.x, coordinates?.y],
+    // Coordinates intentionally NOT in the queryKey — a moving boat would
+    // otherwise re-fire this query on every GPS tick and put the page back
+    // into the fetching state, blocking tool placement. The queryFn closure
+    // still uses the latest `coordinates` value, and the user can force a
+    // re-detect via the "Atnaujinti lokaciją" button (`refetch`).
+    queryKey: ['location', currentFishing?.id],
     queryFn: () => {
       return api.getLocation({
         query: JSON.stringify({


### PR DESCRIPTION
## Summary

While sailing inside a bar (Kuršių mariose / inland / polders), the location auto-detect query refired on every GPS tick. The page sat in a fetching state, blocking the "Pastatyti įrankį" flow ("neina pastatyti įrankio, nes visada refreshinasi lokacija").

The throttle from #136 caps GPS updates to ~50 m, which fixes standing-still jitter but does nothing for a moving boat — the threshold is crossed every few seconds.

### Fix

Drop `coordinates?.x` / `coordinates?.y` from the `useQuery` `queryKey` in all three fishing-tools pages. The `queryFn` closure still reads the latest `coordinates`, so:

- The first truthy `coordinates` flips `enabled` → query fires once and caches.
- Subsequent GPS updates do **not** change the queryKey → no refetch.
- `refetch()` (called by the "Atnaujinti lokaciją" button on `LocationInfo`) still uses the latest closure, so manual re-detection works as before.
- A genuine bar change is handled by the existing manual paths — pencil to pick or explicit refresh.

The other coord usages in the codebase (`BuildTools`, `CaughtFishWeight`, `StartFishingInlandWater`) live inside event-handler closures evaluated on click; they don't drive re-renders and stay as is.

No backend changes.

## Test plan

- [ ] Start a fishing in `Kuršių mariose`. In DevTools → Sensors → Location, set a fixed point inside a bar. Auto-detect resolves; one `GET /locations?...` call.
- [ ] Drift the override coordinates by ~10–20 m every few seconds for ~30 s. Network tab shows **no** further `GET /locations?...` calls. Page does not flicker into spinner.
- [ ] "Pastatyti įrankį" stays usable while coordinates are still updating in the background.
- [ ] Click the pencil → pick a different bar manually → page updates immediately, no refetch storm.
- [ ] Click "Atnaujinti lokaciją" → exactly one fresh `GET /locations?...` call with current coordinates.
- [ ] Repeat the above in `Vidaus vandenyse` and `Polderiuose`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)