### PR TITLE
fix: stop location loading state from flipping on transient GPS errors

### DIFF
--- a/src/components/containers/BuildTools.tsx
+++ b/src/components/containers/BuildTools.tsx
@@ -18,7 +18,7 @@ interface BuiltToolsProps {
 const BuildTools = ({ onClose, location }: BuiltToolsProps) => {
   const queryClient = useQueryClient();
   const [selectedTool, setSelectedTool] = useState<number>();
-  const { coordinates, loading } = useGeolocation();
+  const { coordinates, loading, refresh: refreshGeolocation } = useGeolocation();
 
   const { data: availableTools } = useQuery(['availableTools'], () => api.getAvailableTools(), {
     retry: false,
@@ -75,9 +75,10 @@ const BuildTools = ({ onClose, location }: BuiltToolsProps) => {
         location,
         coordinates: buildToolsCoordinates,
       });
-    } else {
-      handleErrorToast('Nenustatyta buvimo vieta');
+      return;
     }
+    refreshGeolocation();
+    handleErrorToast('Nenustatyta buvimo vieta');
   };
 
   return (

--- a/src/components/popups/CaughtFishWeight.tsx
+++ b/src/components/popups/CaughtFishWeight.tsx
@@ -24,7 +24,7 @@ const CaughtFishWeight = ({ content: { location, toolsGroup }, onClose }: any) =
   const currentRoute = useGetCurrentRoute();
   const { fishTypes, fishTypesLoading } = useFishTypes();
   const { showPopup } = useContext<PopupContextProps>(PopupContext);
-  const { coordinates, loading } = useGeolocation();
+  const { coordinates, loading, refresh: refreshGeolocation } = useGeolocation();
 
   const {
     data: fishingWeights,
@@ -94,11 +94,12 @@ const CaughtFishWeight = ({ content: { location, toolsGroup }, onClose }: any) =
         location,
       };
       weighToolsMutation(params);
-    } else {
-      handleErrorToast(
-        'Nepavyko nustatyti jūsų vietos. Pabandykite dar kartą vėliau ir įsitikinkite, kad naršyklėje suteikti vietos nustatymo leidimai.',
-      );
+      return;
     }
+    refreshGeolocation();
+    handleErrorToast(
+      'Nepavyko nustatyti jūsų vietos. Pabandykite dar kartą vėliau ir įsitikinkite, kad naršyklėje suteikti vietos nustatymo leidimai.',
+    );
   };
 
   return (

--- a/src/components/popups/EndFishing.tsx
+++ b/src/components/popups/EndFishing.tsx
@@ -17,7 +17,7 @@ import LoaderComponent from '../other/LoaderComponent';
 export const EndFishing = ({ onClose }: any) => {
   const queryClient = useQueryClient();
 
-  const { coordinates, loading } = useGeolocation();
+  const { coordinates, loading, refresh: refreshGeolocation } = useGeolocation();
 
   const { mutateAsync: finishFishing, isLoading: finishFishingLoading } = useMutation(
     api.finishFishing,
@@ -36,9 +36,10 @@ export const EndFishing = ({ onClose }: any) => {
   const handleFinishFishing = () => {
     if (coordinates) {
       finishFishing({ coordinates });
-    } else {
-      handleErrorToast(validationTexts.mustAllowToSetCoordinates);
+      return;
     }
+    refreshGeolocation();
+    handleErrorToast(validationTexts.mustAllowToSetCoordinates);
   };
   return (
     <PopUpWithImage

--- a/src/components/popups/SkipFishing.tsx
+++ b/src/components/popups/SkipFishing.tsx
@@ -22,7 +22,7 @@ export const SkipFishing = ({ content, onClose }: any) => {
 
   const [skipReason, setSkipReason] = useState<any>(SickReasons.BAD_WEATHER);
   const [skipReasonNote, setSkipReasonNote] = useState<string>();
-  const { coordinates, loading } = useGeolocation();
+  const { coordinates, loading, refresh: refreshGeolocation } = useGeolocation();
 
   const { isLoading: skipLoading, mutateAsync: skipFishing } = useMutation(api.skipFishing, {
     onError: ({ response }: any) => {
@@ -42,9 +42,10 @@ export const SkipFishing = ({ content, onClose }: any) => {
         coordinates,
         note: skipReason.value === SickReasons.OTHER ? skipReasonNote : skipReason.label,
       });
-    } else {
-      handleErrorToast(validationTexts.mustAllowToSetCoordinates);
+      return;
     }
+    refreshGeolocation();
+    handleErrorToast(validationTexts.mustAllowToSetCoordinates);
   };
 
   return (

--- a/src/components/popups/StartFishing.tsx
+++ b/src/components/popups/StartFishing.tsx
@@ -19,7 +19,7 @@ export const StartFishing = ({ content, onClose }: any) => {
   const queryClient = useQueryClient();
   const { type } = content;
   const { showPopup } = useContext<PopupContextProps>(PopupContext);
-  const { coordinates, loading } = useGeolocation();
+  const { coordinates, loading, refresh: refreshGeolocation } = useGeolocation();
 
   const { isLoading: startLoading, mutateAsync: startFishing } = useMutation(api.startFishing, {
     onError: ({ response }) => {
@@ -38,9 +38,12 @@ export const StartFishing = ({ content, onClose }: any) => {
         type: type,
         coordinates,
       });
-    } else {
-      handleErrorToast(validationTexts.mustAllowToSetCoordinates);
+      return;
     }
+    // No fix yet — re-trigger the geolocation provider so the user can
+    // recover without closing the popup.
+    refreshGeolocation();
+    handleErrorToast(validationTexts.mustAllowToSetCoordinates);
   };
 
   return (

--- a/src/components/popups/StartFishingInlandWater.tsx
+++ b/src/components/popups/StartFishingInlandWater.tsx
@@ -20,7 +20,7 @@ import { IconName } from '../other/Icon';
 const StartFishingInlandWater = ({ onClose }: any) => {
   const queryClient = useQueryClient();
   const [selectedLocation, setSelectedLocation] = useState<any>();
-  const { coordinates, loading } = useGeolocation();
+  const { coordinates, loading, refresh: refreshGeolocation } = useGeolocation();
 
   const getInputValue = (location: any) =>
     location ? `${location?.name}, ${location?.cadastralId}` : '';
@@ -43,9 +43,10 @@ const StartFishingInlandWater = ({ onClose }: any) => {
         coordinates: { x: coordinates?.x, y: coordinates?.y },
         uetkCadastralId: selectedLocation?.cadastralId,
       });
-    } else {
-      handleErrorToast(validationTexts.mustAllowToSetCoordinates);
+      return;
     }
+    refreshGeolocation();
+    handleErrorToast(validationTexts.mustAllowToSetCoordinates);
   };
 
   return (

--- a/src/components/popups/ToolGroupAction.tsx
+++ b/src/components/popups/ToolGroupAction.tsx
@@ -18,7 +18,7 @@ import LoaderComponent from '../other/LoaderComponent';
 
 const ToolGroupAction = ({ onClose, content }: any) => {
   const { toolsGroup, location, showWeightButtons, showCheckButton } = content;
-  const { coordinates, loading } = useGeolocation();
+  const { coordinates, loading, refresh: refreshGeolocation } = useGeolocation();
   const { data: currentFishing, isFetching: currentFishingLoading } = useCurrentFishing();
 
   const queryClient = useQueryClient();
@@ -48,11 +48,12 @@ const ToolGroupAction = ({ onClose, content }: any) => {
         location,
       };
       weighToolsMutation(params);
-    } else {
-      handleErrorToast(
-        'Nepavyko nustatyti jūsų vietos. Pabandykite dar kartą vėliau ir įsitikinkite, kad naršyklėje suteikti vietos nustatymo leidimai.',
-      );
+      return;
     }
+    refreshGeolocation();
+    handleErrorToast(
+      'Nepavyko nustatyti jūsų vietos. Pabandykite dar kartą vėliau ir įsitikinkite, kad naršyklėje suteikti vietos nustatymo leidimai.',
+    );
   };
 
   const { mutateAsync: returnToolsMutation, isLoading: removeToolLoading } = useMutation(

--- a/src/components/providers/GeolocationProvider.tsx
+++ b/src/components/providers/GeolocationProvider.tsx
@@ -38,6 +38,16 @@ const INITIAL_FIX_OPTIONS: PositionOptions = {
 // of meters, so 50 m is well within the same bucket).
 const MIN_COORDINATE_DELTA = 0.0005;
 
+// Safety net: if neither the initial fix nor the watch yields a position
+// within this window, flip `loading` to false so consumers can fall back to
+// manual location entry / the "Atnaujinti lokaciją" retry button. The watch
+// continues running silently in the background, so a fix arriving later still
+// populates `coordinates`. Without this timer, a transient watch failure
+// followed by a slow initial fix used to flip loading to false with
+// `coordinates === null`, causing action popups to fire the
+// "mustAllowToSetCoordinates" toast even though GPS was still warming up.
+const SETTLE_LOADING_TIMEOUT_MS = 15000;
+
 export const GeolocationContext = createContext<GeolocationContextProps>({
   coordinates: null,
   loading: true,
@@ -49,15 +59,16 @@ export const GeolocationProvider: React.FC<{ children: React.ReactNode }> = ({ c
   const [loading, setLoading] = useState(true);
 
   const watchIdRef = useRef<number | null>(null);
-  const resolvedInitialRef = useRef(false);
+  const settleTimerRef = useRef<number | null>(null);
   const loadingToastShownRef = useRef(false);
   const permissionDeniedRef = useRef(false);
 
-  const finishInitialResolve = () => {
-    if (!resolvedInitialRef.current) {
-      resolvedInitialRef.current = true;
-      setLoading(false);
-      loadingToastShownRef.current = false;
+  const settleLoading = () => {
+    setLoading(false);
+    loadingToastShownRef.current = false;
+    if (settleTimerRef.current !== null) {
+      clearTimeout(settleTimerRef.current);
+      settleTimerRef.current = null;
     }
   };
 
@@ -77,7 +88,7 @@ export const GeolocationProvider: React.FC<{ children: React.ReactNode }> = ({ c
       }
       return next;
     });
-    finishInitialResolve();
+    settleLoading();
   };
 
   const handleGeolocationError = (err: GeolocationPositionError, isWatch: boolean) => {
@@ -88,12 +99,21 @@ export const GeolocationProvider: React.FC<{ children: React.ReactNode }> = ({ c
         navigator.geolocation.clearWatch(watchIdRef.current);
         watchIdRef.current = null;
       }
+      settleLoading();
+      return;
     }
-    // Silent on unavailable / timeout — the continuous watch is running and
-    // will recover on its own. Surfacing a toast for every transient GPS
-    // hiccup spammed users on a moving boat.
 
-    finishInitialResolve();
+    // Transient unavailable / timeout. We deliberately do NOT settle loading
+    // here, because the watch is continuous and is still trying — flipping
+    // loading=false while coordinates is still null tricks consumers into
+    // enabling their action buttons, after which the user taps and hits the
+    // "mustAllowToSetCoordinates" toast even though GPS was just slow. The
+    // safety-net timer in requestCurrentPosition guarantees loading
+    // eventually flips so the manual-entry UI isn't blocked forever.
+    if (isWatch) return;
+
+    // Initial fast fix failed (often a cold-cache 8s timeout). Stay loading
+    // and lean on the continuous watch + safety-net timer.
   };
 
   const startWatch = () => {
@@ -118,12 +138,18 @@ export const GeolocationProvider: React.FC<{ children: React.ReactNode }> = ({ c
     }
 
     setLoading(true);
-    resolvedInitialRef.current = false;
 
     if (!loadingToastShownRef.current) {
       loadingToastShownRef.current = true;
       handleGeolocationToast(true);
     }
+
+    if (settleTimerRef.current !== null) clearTimeout(settleTimerRef.current);
+    settleTimerRef.current = window.setTimeout(() => {
+      settleTimerRef.current = null;
+      setLoading(false);
+      loadingToastShownRef.current = false;
+    }, SETTLE_LOADING_TIMEOUT_MS);
 
     // Start the continuous watch immediately so we don't depend on a single
     // getCurrentPosition succeeding — boat GPS often takes 10s+ for the first
@@ -144,6 +170,10 @@ export const GeolocationProvider: React.FC<{ children: React.ReactNode }> = ({ c
       if (watchIdRef.current !== null) {
         navigator.geolocation.clearWatch(watchIdRef.current);
         watchIdRef.current = null;
+      }
+      if (settleTimerRef.current !== null) {
+        clearTimeout(settleTimerRef.current);
+        settleTimerRef.current = null;
       }
     };
   }, [requestCurrentPosition]);

--- a/src/pages/FishingToolsEstuary.tsx
+++ b/src/pages/FishingToolsEstuary.tsx
@@ -22,7 +22,7 @@ import api from '../utils/api';
 const FishingToolsEstuary = () => {
   const [showBuildTools, setShowBuildTools] = useState(false);
   const { data: currentFishing, isLoading: currentFishingLoading } = useCurrentFishing();
-  const { coordinates } = useGeolocation();
+  const { coordinates, refresh: refreshGeolocation } = useGeolocation();
 
   const locationType = currentFishing?.type;
   const [manualLocation, setManualLocation] = useState<any>();
@@ -112,7 +112,13 @@ const FishingToolsEstuary = () => {
         locationLoading={locationLoading}
         setLocationManually={setManualLocation}
         locationType={LocationType.ESTUARY}
-        renewLocation={refetch}
+        renewLocation={() => {
+          // Also kick the geolocation provider — the query is gated on
+          // `!!coordinates`, so refetching alone is a no-op when GPS hasn't
+          // produced a fix yet.
+          refreshGeolocation();
+          refetch();
+        }}
       />
       <Container>
         {builtToolsFetching || (builtTools === undefined && !!showBuildToolsButton) ? (

--- a/src/pages/FishingToolsInlandWaters.tsx
+++ b/src/pages/FishingToolsInlandWaters.tsx
@@ -25,7 +25,7 @@ const FishingTools = () => {
   const isEstuary = currentFishing?.type === LocationType.ESTUARY;
   const locationType = currentFishing?.type;
   const [manualLocation, setManualLocation] = useState<any>();
-  const { coordinates, loading } = useGeolocation();
+  const { coordinates, loading, refresh: refreshGeolocation } = useGeolocation();
 
   const {
     data: location,
@@ -112,7 +112,14 @@ const FishingTools = () => {
         location={currentLocation}
         locationLoading={locationLoading || loading}
         setLocationManually={setManualLocation}
-        renewLocation={refetch}
+        renewLocation={() => {
+          // The location query is gated on `!!coordinates`; if GPS hasn't
+          // produced a fix yet, refetch alone is a no-op. Re-trigger the
+          // geolocation provider too so the user can recover from a stuck
+          // "no fix" state.
+          refreshGeolocation();
+          refetch();
+        }}
       />
       <Container>
         {builtToolsFetching || (builtTools === undefined && !!showBuildToolsButton) ? (

--- a/src/pages/FishingToolsPolders.tsx
+++ b/src/pages/FishingToolsPolders.tsx
@@ -25,7 +25,7 @@ const FishingTools = () => {
   const { data: currentFishing, isLoading: currentFishingLoading } = useCurrentFishing();
   const locationType = currentFishing?.type;
   const [manualLocation, setManualLocation] = useState<any>();
-  const { coordinates, loading } = useGeolocation();
+  const { coordinates, loading, refresh: refreshGeolocation } = useGeolocation();
 
   const {
     data: location,
@@ -122,7 +122,14 @@ const FishingTools = () => {
             municipality: picked?.municipality || location?.municipality,
           });
         }}
-        renewLocation={refetch}
+        renewLocation={() => {
+          // The location query is gated on `!!coordinates`; if GPS hasn't
+          // produced a fix yet, refetch alone is a no-op. Re-trigger the
+          // geolocation provider too so the user can recover from a stuck
+          // "no fix" state.
+          refreshGeolocation();
+          refetch();
+        }}
       />
       {polderPicked && (
         <Container>

--- a/src/pages/FishingWeight.tsx
+++ b/src/pages/FishingWeight.tsx
@@ -27,7 +27,7 @@ const FishingWeight = () => {
   const { fishingWeights, fishingWeightsLoading } = useFishWeights();
   const { fishingWeightLoading, fishingWeightMutation } = useFishingWeightMutation();
   const { showPopup } = useContext<PopupContextProps>(PopupContext);
-  const { coordinates, loading } = useGeolocation();
+  const { coordinates, loading, refresh: refreshGeolocation } = useGeolocation();
 
   if (currentFishingLoading || fishTypesLoading || fishingWeightsLoading) {
     return <LoaderComponent />;
@@ -65,7 +65,10 @@ const FishingWeight = () => {
   };
 
   const handleSubmit = (values: any) => {
-    if (!coordinates) return handleErrorToast(validationTexts.mustAllowToSetCoordinates);
+    if (!coordinates) {
+      refreshGeolocation();
+      return handleErrorToast(validationTexts.mustAllowToSetCoordinates);
+    }
 
     const mappedWeights = mapWeights(values);
 


### PR DESCRIPTION
## Summary

Repairs the \"sometimes location works, sometimes it doesn't\" behavior reported by anglers.

The root cause was in `GeolocationProvider.handleGeolocationError`: it called `finishInitialResolve()` (which flips `loading=false`) on **every** geolocation error, including transient `watchPosition` timeouts and `POSITION_UNAVAILABLE`. On boats with slow GPS warm-up — or any browser that's eager with `POSITION_UNAVAILABLE` (Edge does this aggressively) — the provider would surface `loading=false` with `coordinates=null` while the watch was still trying. Consumers treated that as \"ready\", enabled their action buttons, and the user got the misleading `Privalote leisti nustatyti koordinates` toast on tap.

## Changes

- `GeolocationProvider`: watch + initial-fix transient errors are now silent. Only `PERMISSION_DENIED` toasts and tears down the watch. A 15s safety-net timer caps `loading` so the manual-entry UI isn't blocked forever; the watch continues silently and can still populate `coordinates` after the timer fires.
- `FishingTools{Estuary,InlandWaters,Polders}` — the `Atnaujinti lokaciją` button now triggers `refresh()` on the geolocation provider in addition to refetching the location query (the query is gated on `!!coordinates`, so the refetch alone was a no-op when GPS hadn't yielded a fix).
- 8 popup / page consumers now call `refresh()` on the null-coordinates path, so the user can recover without closing the popup: `StartFishing`, `StartFishingInlandWater`, `SkipFishing`, `EndFishing`, `CaughtFishWeight`, `ToolGroupAction`, `BuildTools`, `FishingWeight`.

## Test plan

- [ ] Manual: open the app on a phone with weak GPS — confirm the loading toast persists until either a fix arrives or the 15s safety net fires (no premature \"mustAllow\" toast).
- [ ] Manual: deny geolocation permission — denial toast still appears and the watch stays cleared.
- [ ] Manual: revoke permission mid-session, tap an action — `refresh()` re-shows the denial toast (expected).
- [ ] Manual on Microsoft Edge: verify the app no longer settles into a broken state on cold load.
- [ ] Manual: tap \"Atnaujinti lokaciją\" with a stuck no-fix state — geolocation re-attempts.
- [ ] Manual: with coordinates already populated, weigh tools / save shore weight — happy path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)