### PR TITLE
fix(location): mark manual only for typed WGS coords; use real GPS otherwise

### DIFF
--- a/src/components/containers/BuildTools.tsx
+++ b/src/components/containers/BuildTools.tsx
@@ -65,19 +65,19 @@ const BuildTools = ({ onClose, location }: BuiltToolsProps) => {
   };
 
   const handleBuildTools = () => {
-    const buildToolsCoordinates: any = {
-      x: location?.x || coordinates?.x,
-      y: location?.y || coordinates?.y,
-    };
+    // Only the manually-typed WGS path overrides device GPS. Picking a
+    // bar/water-body from the dropdown is just metadata — we still want
+    // the actual phone fix as the event coordinate so the admin map
+    // doesn't show every company stacked on the bar centroid.
+    const buildToolsCoordinates: any = location?.manual
+      ? { x: location?.x, y: location?.y }
+      : { x: coordinates?.x, y: coordinates?.y };
     if (buildToolsCoordinates.x && buildToolsCoordinates.y) {
       buildToolsMutation({
         tools: selectedTool,
         location,
         coordinates: buildToolsCoordinates,
-        // Auto `getLocation` returns no x/y; manual `getFishingSections`
-        // picker carries the bar centroid x/y. Source of truth for the
-        // manual-pick flag without prop-threading from caller pages.
-        locationManual: !!(location?.x && location?.y),
+        locationManual: !!location?.manual,
       });
       return;
     }

--- a/src/components/forms/LocationForm.tsx
+++ b/src/components/forms/LocationForm.tsx
@@ -38,7 +38,9 @@ const LocationForm = ({ handleSetLocationManually, locationType, onClose }: any)
 
   const handleSubmit = async (values: any) => {
     if (values.location) {
-      handleSetLocationManually(values.location);
+      // Picking a bar/water-body from the dropdown is just metadata — coords
+      // still come from the device GPS, so this is NOT a manual location.
+      handleSetLocationManually({ ...values.location, manual: false });
       onClose();
     } else if (values.x && values.y) {
       queryClient
@@ -54,7 +56,15 @@ const LocationForm = ({ handleSetLocationManually, locationType, onClose }: any)
           },
         })
         .then((data) => {
-          handleSetLocationManually({ ...data, x: values.x, y: values.y });
+          // User explicitly typed WGS coordinates → admin gets the manual
+          // warning. The x/y stay on the object so the build/weigh callers
+          // can override their GPS coords with the typed values.
+          handleSetLocationManually({
+            ...data,
+            x: Number(values.x),
+            y: Number(values.y),
+            manual: true,
+          });
           queryClient.refetchQueries(['builtTools', data?.id]);
           onClose();
         })

--- a/src/components/popups/CaughtFishWeight.tsx
+++ b/src/components/popups/CaughtFishWeight.tsx
@@ -92,10 +92,7 @@ const CaughtFishWeight = ({ content: { location, toolsGroup }, onClose }: any) =
         data: mappedWeights,
         coordinates,
         location,
-        // Auto `getLocation` returns no x/y; manual `getFishingSections`
-        // picker carries the bar centroid x/y. Source of truth without
-        // having to prop-thread a flag through popup chains.
-        locationManual: !!(location?.x && location?.y),
+        locationManual: !!location?.manual,
       };
       weighToolsMutation(params);
       return;

--- a/src/components/popups/ToolGroupAction.tsx
+++ b/src/components/popups/ToolGroupAction.tsx
@@ -40,11 +40,9 @@ const ToolGroupAction = ({ onClose, content }: any) => {
     },
   );
 
-  // Auto-detect `getLocation` returns just {id,name,type,municipality}; the
-  // manual `getFishingSections` picker also carries x/y (bar centroid). Use
-  // that as the source of truth so every event creation path flags manual
-  // picks without prop-threading through every popup.
-  const locationManual = !!(location?.x && location?.y);
+  // Set in LocationForm when the user types WGS coordinates — admin uses
+  // this to render a warning on the affected events.
+  const locationManual = !!location?.manual;
 
   const handleSubmit = () => {
     if (coordinates?.x && coordinates?.y) {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -19,6 +19,7 @@ export interface Location {
   municipality: { id: number; name: string };
   x?: number;
   y?: number;
+  manual?: boolean;
 }
 
 export interface Coordinates {


### PR DESCRIPTION
## Summary
- The previous heuristic `!!(location?.x && location?.y)` couldn't tell apart **dropdown bar pick** (bar centroid as x/y) and **typed WGS coords** (user-entered x/y) — every dropdown pick was being flagged manual, and `BuildTools` was using the bar centroid as the event coordinate.
- That's why three boats picking the same Kuršių marios bar ended up stacked on a single point in water on the admin map (matches the field report: *"trys skirtingi telefonai rodo tą pačią vietą vandenyje"*).
- `LocationForm` now sets an explicit `manual: boolean` on the location object — `true` only when the user typed lat/lon. `BuildTools`, `CaughtFishWeight`, and `ToolGroupAction` read that flag instead of inferring from x/y. `BuildTools` also stops overriding the device GPS unless the user explicitly typed coords.

## Test plan
- [ ] Pick bar from select → event in DB has `location_manual=false`, `geom` matches device GPS (not centroid).
- [ ] Type WGS coords manually → event has `location_manual=true`, `geom` matches the typed values.
- [ ] No bar picked (pure auto-GPS) → `location_manual=false`, `geom` is device GPS.
- [ ] Inland-waters select still works (location resolves, builtTools loads).
- [ ] Admin journal: warning icon only appears for the typed-coords path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)