### PR TITLE
fix(events): consume {lat, lng} from history response

### DIFF
--- a/src/components/containers/FishingEventDetails.tsx
+++ b/src/components/containers/FishingEventDetails.tsx
@@ -17,11 +17,9 @@ const FishingEventDetails = ({ event }: any) => {
     (e) => e === event.type,
   );
 
-  // `getHistory` already returns WGS84 from `geomToWgs`, where x=lng and
-  // y=lat. Show lat first to match the admin journal and the convention
-  // every consumer pastes into Google Maps.
+  // `getHistory` returns `{ lat, lng }` in WGS84 (see geomToWgs).
   const coordinates = event.coordinates
-    ? `${event.coordinates.y?.toFixed(6)}, ${event.coordinates.x?.toFixed(6)}`
+    ? `${event.coordinates.lat?.toFixed(6)}, ${event.coordinates.lng?.toFixed(6)}`
     : '-';
 
   return (

--- a/src/components/containers/FishingEventDetails.tsx
+++ b/src/components/containers/FishingEventDetails.tsx
@@ -17,8 +17,12 @@ const FishingEventDetails = ({ event }: any) => {
     (e) => e === event.type,
   );
 
-  //TODO: should be converted to wgs
-  const coordinates = event.coordinates ? `${event.coordinates.x?.toFixed(6)}, ${event.coordinates.y?.toFixed(6)}` : '-';
+  // `getHistory` already returns WGS84 from `geomToWgs`, where x=lng and
+  // y=lat. Show lat first to match the admin journal and the convention
+  // every consumer pastes into Google Maps.
+  const coordinates = event.coordinates
+    ? `${event.coordinates.y?.toFixed(6)}, ${event.coordinates.x?.toFixed(6)}`
+    : '-';
 
   return (
     <Container>


### PR DESCRIPTION
## Summary
- Pairs with [biip-zvejyba-api#119](https://github.com/AplinkosMinisterija/biip-zvejyba-api/pull/119) — the history endpoint now returns event coordinates as `{ lat, lng }` instead of `{ x, y }` (which previously meant lng, lat — a recurring source of bugs).
- `FishingEventDetails` consumes the new shape and prints lat first, matching admin and Google-Maps-style copy/paste.

## Test plan
- [ ] After both PRs merge, open a fishing event detail in the app → coords look like `55.329931, 23.905544`.
- [ ] Number matches the marker on `PreviewMap`.
- [ ] Same event opened in admin journal renders the same coord string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)