### PR TITLE
fix(tools): hide 'Sugrąžinti į sandėlį' when BE would block it

### DIFF
--- a/src/components/cards/ToolsGroupCard.tsx
+++ b/src/components/cards/ToolsGroupCard.tsx
@@ -18,6 +18,7 @@ interface ToolsGroupCardProps {
   isDisabled?: boolean;
   location?: any;
   showCheckButton: boolean;
+  canReturnToWarehouse?: boolean;
 }
 const ToolsGroupCard = ({
   toolsGroup,
@@ -26,6 +27,7 @@ const ToolsGroupCard = ({
   isDisabled = false,
   location,
   showCheckButton,
+  canReturnToWarehouse = true,
 }: ToolsGroupCardProps) => {
   const isCheckedTool = !!toolsGroup?.weightEvent;
   const { showPopup } = useContext<PopupContextProps>(PopupContext);
@@ -44,6 +46,7 @@ const ToolsGroupCard = ({
                   toolsGroup,
                   showWeightButtons: !isCheckedTool,
                   showCheckButton,
+                  canReturnToWarehouse,
                 },
               });
             } else {

--- a/src/components/popups/ToolGroupAction.tsx
+++ b/src/components/popups/ToolGroupAction.tsx
@@ -17,7 +17,13 @@ import { PopupContext, PopupContextProps } from '../providers/PopupProvider';
 import LoaderComponent from '../other/LoaderComponent';
 
 const ToolGroupAction = ({ onClose, content }: any) => {
-  const { toolsGroup, location, showWeightButtons, showCheckButton } = content;
+  const {
+    toolsGroup,
+    location,
+    showWeightButtons,
+    showCheckButton,
+    canReturnToWarehouse = true,
+  } = content;
   const { coordinates, loading, refresh: refreshGeolocation } = useGeolocation();
   const { data: currentFishing, isFetching: currentFishingLoading } = useCurrentFishing();
 
@@ -119,13 +125,15 @@ const ToolGroupAction = ({ onClose, content }: any) => {
               )}
             </>
           )}
-          <MenuButton
-            label="Sugrąžinti į sandėlį"
-            icon={IconName.return}
-            onClick={returnToolsMutation}
-            loading={removeToolLoading || loading}
-            isActive={!removeToolLoading}
-          />
+          {canReturnToWarehouse && (
+            <MenuButton
+              label="Sugrąžinti į sandėlį"
+              icon={IconName.return}
+              onClick={returnToolsMutation}
+              loading={removeToolLoading || loading}
+              isActive={!removeToolLoading}
+            />
+          )}
         </PopupContainer>
       )}
     </Popup>

--- a/src/pages/FishingToolsEstuary.tsx
+++ b/src/pages/FishingToolsEstuary.tsx
@@ -12,6 +12,7 @@ import LoaderComponent from '../components/other/LoaderComponent';
 import LocationInfo from '../components/other/LocationInfo';
 import { NotFound } from '../components/other/NotFound';
 import {
+  computeBuiltToolsGuards,
   handleErrorToastFromServer,
   LocationType,
   useCurrentFishing,
@@ -76,34 +77,8 @@ const FishingToolsEstuary = () => {
   const currentLocation = manualLocation || location;
   const showBuildToolsButton = !!currentLocation?.id;
 
-  const { toolTypesCounts, checkedToolTypesCounts } = builtTools.reduce(
-    (acc, tool) => {
-      const id = tool.tools?.[0]?.toolType?.id;
-      if (!id) return acc;
-
-      acc.toolTypesCounts[id] = (acc.toolTypesCounts[id] ?? 0) + 1;
-
-      if (tool.weightEvent) {
-        acc.checkedToolTypesCounts[id] = (acc.checkedToolTypesCounts[id] ?? 0) + 1;
-      }
-
-      return acc;
-    },
-    {
-      checkedToolTypesCounts: {} as Record<string, number>,
-      toolTypesCounts: {} as Record<string, number>,
-    },
-  );
-
-  const hasAnyChecked = Object.keys(checkedToolTypesCounts).length > 0;
-
-  const notCompletedToolType = hasAnyChecked
-    ? Object.keys(toolTypesCounts).find(
-        (key) =>
-          (checkedToolTypesCounts[key] ?? 0) > 0 &&
-          checkedToolTypesCounts[key] < toolTypesCounts[key],
-      )
-    : undefined;
+  const { toolTypesCounts, checkedToolTypesCounts, notCompletedToolType, blockReturnToolTypes } =
+    computeBuiltToolsGuards(builtTools);
 
   return (
     <DefaultLayout>
@@ -128,11 +103,19 @@ const FishingToolsEstuary = () => {
         ) : (
           map(builtTools, (toolsGroup: any) => {
             const toolTypeId = toolsGroup.tools[0].toolType.id;
+            const typeKey = String(toolTypeId);
             const disableTool =
-              !!notCompletedToolType && notCompletedToolType !== toolTypeId.toString();
+              !!notCompletedToolType && notCompletedToolType !== typeKey;
 
             const showCheckButton =
-              toolTypesCounts[toolTypeId] - (checkedToolTypesCounts?.[toolTypeId] || 0) > 1;
+              toolTypesCounts[typeKey] - (checkedToolTypesCounts?.[typeKey] || 0) > 1;
+
+            // Mirror of BE `assertSiblingsHaveFishLogged` — hide the
+            // "Sugrąžinti į sandėlį" option when returning this tool would
+            // be rejected (last unchecked of a type with only empty
+            // Patikrinta siblings, no fish anywhere).
+            const canReturnToWarehouse =
+              !!toolsGroup.weightEvent || !blockReturnToolTypes.has(typeKey);
 
             return (
               <ToolsGroupCard
@@ -141,6 +124,7 @@ const FishingToolsEstuary = () => {
                 toolsGroup={toolsGroup}
                 location={currentLocation}
                 showCheckButton={showCheckButton}
+                canReturnToWarehouse={canReturnToWarehouse}
                 isDisabled={disableTool}
               />
             );

--- a/src/pages/FishingToolsInlandWaters.tsx
+++ b/src/pages/FishingToolsInlandWaters.tsx
@@ -12,6 +12,7 @@ import LoaderComponent from '../components/other/LoaderComponent';
 import LocationInfo from '../components/other/LocationInfo';
 import { NotFound } from '../components/other/NotFound';
 import {
+  computeBuiltToolsGuards,
   handleErrorToastFromServer,
   LocationType,
   useCurrentFishing,
@@ -76,34 +77,8 @@ const FishingTools = () => {
     return <LoaderComponent />;
   }
 
-  const { toolTypesCounts, checkedToolTypesCounts } = builtTools.reduce(
-    (acc, tool) => {
-      const id = tool.tools?.[0]?.toolType?.id;
-      if (!id) return acc;
-
-      acc.toolTypesCounts[id] = (acc.toolTypesCounts[id] ?? 0) + 1;
-
-      if (tool.weightEvent) {
-        acc.checkedToolTypesCounts[id] = (acc.checkedToolTypesCounts[id] ?? 0) + 1;
-      }
-
-      return acc;
-    },
-    {
-      checkedToolTypesCounts: {} as Record<string, number>,
-      toolTypesCounts: {} as Record<string, number>,
-    },
-  );
-
-  const hasAnyChecked = Object.keys(checkedToolTypesCounts).length > 0;
-
-  const notCompletedToolType = hasAnyChecked
-    ? Object.keys(toolTypesCounts).find(
-        (key) =>
-          (checkedToolTypesCounts[key] ?? 0) > 0 &&
-          checkedToolTypesCounts[key] < toolTypesCounts[key],
-      )
-    : undefined;
+  const { toolTypesCounts, checkedToolTypesCounts, notCompletedToolType, blockReturnToolTypes } =
+    computeBuiltToolsGuards(builtTools);
 
   return (
     <DefaultLayout>
@@ -129,11 +104,15 @@ const FishingTools = () => {
         ) : (
           map(builtTools, (toolsGroup) => {
             const toolTypeId = toolsGroup.tools[0].toolType.id;
+            const typeKey = String(toolTypeId);
             const disableTool =
-              !!notCompletedToolType && notCompletedToolType !== toolTypeId.toString();
+              !!notCompletedToolType && notCompletedToolType !== typeKey;
 
             const showCheckButton =
-              toolTypesCounts[toolTypeId] - (checkedToolTypesCounts?.[toolTypeId] || 0) > 1;
+              toolTypesCounts[typeKey] - (checkedToolTypesCounts?.[typeKey] || 0) > 1;
+
+            const canReturnToWarehouse =
+              !!toolsGroup.weightEvent || !blockReturnToolTypes.has(typeKey);
 
             return (
               <ToolsGroupCard
@@ -142,6 +121,7 @@ const FishingTools = () => {
                 toolsGroup={toolsGroup}
                 location={currentLocation}
                 showCheckButton={showCheckButton}
+                canReturnToWarehouse={canReturnToWarehouse}
                 isDisabled={disableTool}
               />
             );

--- a/src/pages/FishingToolsPolders.tsx
+++ b/src/pages/FishingToolsPolders.tsx
@@ -12,6 +12,7 @@ import LoaderComponent from '../components/other/LoaderComponent';
 import LocationInfo from '../components/other/LocationInfo';
 import { NotFound } from '../components/other/NotFound';
 import {
+  computeBuiltToolsGuards,
   device,
   handleErrorToastFromServer,
   LocationType,
@@ -78,34 +79,8 @@ const FishingTools = () => {
     return <LoaderComponent />;
   }
 
-  const { toolTypesCounts, checkedToolTypesCounts } = builtTools.reduce(
-    (acc, tool) => {
-      const id = tool.tools?.[0]?.toolType?.id;
-      if (!id) return acc;
-
-      acc.toolTypesCounts[id] = (acc.toolTypesCounts[id] ?? 0) + 1;
-
-      if (tool.weightEvent) {
-        acc.checkedToolTypesCounts[id] = (acc.checkedToolTypesCounts[id] ?? 0) + 1;
-      }
-
-      return acc;
-    },
-    {
-      checkedToolTypesCounts: {} as Record<string, number>,
-      toolTypesCounts: {} as Record<string, number>,
-    },
-  );
-
-  const hasAnyChecked = Object.keys(checkedToolTypesCounts).length > 0;
-
-  const notCompletedToolType = hasAnyChecked
-    ? Object.keys(toolTypesCounts).find(
-        (key) =>
-          (checkedToolTypesCounts[key] ?? 0) > 0 &&
-          checkedToolTypesCounts[key] < toolTypesCounts[key],
-      )
-    : undefined;
+  const { toolTypesCounts, checkedToolTypesCounts, notCompletedToolType, blockReturnToolTypes } =
+    computeBuiltToolsGuards(builtTools);
 
   return (
     <DefaultLayout>
@@ -140,11 +115,15 @@ const FishingTools = () => {
           ) : (
             map(builtTools, (toolsGroup: any) => {
               const toolTypeId = toolsGroup.tools[0].toolType.id;
+              const typeKey = String(toolTypeId);
               const disableTool =
-                !!notCompletedToolType && notCompletedToolType !== toolTypeId.toString();
+                !!notCompletedToolType && notCompletedToolType !== typeKey;
 
               const showCheckButton =
-                toolTypesCounts[toolTypeId] - (checkedToolTypesCounts?.[toolTypeId] || 0) > 1;
+                toolTypesCounts[typeKey] - (checkedToolTypesCounts?.[typeKey] || 0) > 1;
+
+              const canReturnToWarehouse =
+                !!toolsGroup.weightEvent || !blockReturnToolTypes.has(typeKey);
 
               return (
                 <ToolsGroupCard
@@ -153,6 +132,7 @@ const FishingTools = () => {
                   toolsGroup={toolsGroup}
                   location={currentLocation}
                   showCheckButton={showCheckButton}
+                  canReturnToWarehouse={canReturnToWarehouse}
                   isDisabled={disableTool}
                 />
               );

--- a/src/utils/functions.ts
+++ b/src/utils/functions.ts
@@ -214,6 +214,63 @@ export const getBuiltToolInfo = (toolsGroup: ToolsGroup) => {
   };
 };
 
+export type BuiltToolsGuards = {
+  toolTypesCounts: Record<string, number>;
+  checkedToolTypesCounts: Record<string, number>;
+  withFishToolTypesCounts: Record<string, number>;
+  notCompletedToolType?: string;
+  blockReturnToolTypes: Set<string>;
+};
+
+// Pre-computes the per-tool-type aggregates the tool-list pages need:
+// total / checked / with-fish counts, the type that's mid-checking, and the
+// types where returning the last unchecked tool would silently lose the
+// catch. Mirrors the BE `assertSiblingsHaveFishLogged` guard so the UI can
+// hide the "Sugrąžinti į sandėlį" button before the server errors out.
+export const computeBuiltToolsGuards = (builtTools: any[]): BuiltToolsGuards => {
+  const acc = {
+    toolTypesCounts: {} as Record<string, number>,
+    checkedToolTypesCounts: {} as Record<string, number>,
+    withFishToolTypesCounts: {} as Record<string, number>,
+  };
+
+  for (const tool of builtTools ?? []) {
+    const id = tool?.tools?.[0]?.toolType?.id;
+    if (id == null) continue;
+    const key = String(id);
+    acc.toolTypesCounts[key] = (acc.toolTypesCounts[key] ?? 0) + 1;
+    if (tool.weightEvent) {
+      acc.checkedToolTypesCounts[key] = (acc.checkedToolTypesCounts[key] ?? 0) + 1;
+      const data = tool.weightEvent.data;
+      if (data && Object.keys(data).length > 0) {
+        acc.withFishToolTypesCounts[key] = (acc.withFishToolTypesCounts[key] ?? 0) + 1;
+      }
+    }
+  }
+
+  const hasAnyChecked = Object.keys(acc.checkedToolTypesCounts).length > 0;
+
+  const notCompletedToolType = hasAnyChecked
+    ? Object.keys(acc.toolTypesCounts).find(
+        (key) =>
+          (acc.checkedToolTypesCounts[key] ?? 0) > 0 &&
+          acc.checkedToolTypesCounts[key] < acc.toolTypesCounts[key],
+      )
+    : undefined;
+
+  const blockReturnToolTypes = new Set<string>();
+  for (const key of Object.keys(acc.toolTypesCounts)) {
+    const total = acc.toolTypesCounts[key];
+    const checked = acc.checkedToolTypesCounts[key] ?? 0;
+    const withFish = acc.withFishToolTypesCounts[key] ?? 0;
+    if (total - checked === 1 && checked > 0 && withFish === 0) {
+      blockReturnToolTypes.add(key);
+    }
+  }
+
+  return { ...acc, notCompletedToolType, blockReturnToolTypes };
+};
+
 export const getReactQueryErrorMessage = (response?: ReactQueryError) =>
   response?.data?.type || response?.data?.message || 'error';
 


### PR DESCRIPTION
## Summary

Pairs with [biip-zvejyba-api#120](https://github.com/AplinkosMinisterija/biip-zvejyba-api/pull/120). The server now rejects `removeTools` when the user tries to return the last unchecked tool of a type whose siblings only got empty Patikrinta events. Letting the user click a button that errors out is bad UX — better to drop the option entirely so they're guided toward weighing fish or checking the remaining tools first.

## What changed
- New `computeBuiltToolsGuards` helper in `src/utils/functions.ts` collects the per-tool-type counts (`total`, `checked`, `withFish`) and produces the same `blockReturnToolTypes` set the BE guard uses.
- Replaces the three duplicated reduces in `FishingToolsEstuary`, `FishingToolsInlandWaters`, and `FishingToolsPolders` with a single call to the helper.
- Each page passes a `canReturnToWarehouse` boolean per tool to `ToolsGroupCard` → `ToolGroupAction`, which simply omits the menu button when `false`.
- Self-check exception kept consistent with BE: if the tool itself already has a weight event (with or without fish), the option stays — that's why an already-Patikrinta tool can still be returned.

## Test plan
- [ ] 3 nets in bar A, Patikrinta on 2 (empty), open the 3rd → no "Sugrąžinti į sandėlį" button in the menu; "Sverti žuvį laive" still visible. Weigh fish → button returns.
- [ ] 3 nets in bar A, Patikrinta on 2 (empty), open one of the 2 patikrinta ones → "Sugrąžinti į sandėlį" still visible (self has weight event).
- [ ] 3 nets in bar A weighed with fish, 1 unchecked → 3 nets in bar B (none touched) → bar B nets all have the return button (different location scope).
- [ ] Single net in a bar, never checked → return button visible.
- [ ] Estuary, Inland Waters and Polders pages all behave the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)