### PR TITLE
fix(geolocation): drop cell/WiFi triangulation fixes (accuracy > 100m)

### DIFF
--- a/src/components/providers/GeolocationProvider.tsx
+++ b/src/components/providers/GeolocationProvider.tsx
@@ -38,6 +38,15 @@ const INITIAL_FIX_OPTIONS: PositionOptions = {
 // of meters, so 50 m is well within the same bucket).
 const MIN_COORDINATE_DELTA = 0.0005;
 
+// Reject any fix worse than this — `enableHighAccuracy: false` initial
+// fixes (cell / WiFi triangulation) can be 500–5000 m off in coastal
+// Lithuania, which is what the field audit reported as "all points
+// raised up" on the admin map. Skipping the position keeps the watch
+// running and lets a real GPS fix arrive seconds later. 100 m is well
+// inside any bar / polder / lake bucket but tight enough to make
+// triangulation fixes unusable.
+const MAX_ACCURACY_METERS = 100;
+
 // Safety net: if neither the initial fix nor the watch yields a position
 // within this window, flip `loading` to false so consumers can fall back to
 // manual location entry / the "Atnaujinti lokaciją" retry button. The watch
@@ -73,6 +82,12 @@ export const GeolocationProvider: React.FC<{ children: React.ReactNode }> = ({ c
   };
 
   const applyPosition = (position: GeolocationPosition) => {
+    // Triangulation / coarse fixes report accuracy in the high hundreds or
+    // thousands of meters. Holding onto whatever the previous (or no) fix
+    // was buys time for the high-accuracy watch to deliver a real GPS fix.
+    const accuracy = position.coords.accuracy ?? Infinity;
+    if (accuracy > MAX_ACCURACY_METERS) return;
+
     setCoordinates((prev) => {
       const next = {
         x: position.coords.longitude,


### PR DESCRIPTION
## Summary

Field audit reported every event in fishing 301 clustered on land near the angler's home instead of in Kuršių marios where they picked bar 23. The phone was reporting its actual position at submit time — the problem was the position itself.

Root cause: our provider's initial `getCurrentPosition` uses `enableHighAccuracy: false` so the user doesn't have to wait 8s+ for the first fix. In coastal cities that fallback returns **cell-tower / WiFi triangulation** routinely 500–5000 m off (and the same thing happens in a desktop browser via the ISP — the user confirmed *"buna per telefona ir narsykle, tai gal provideri interneto nurodo ir nesamone"*). The watch picks up a real GPS fix moments later, but by then the user has already pressed a button.

## Fix

Refuse any fix where `position.coords.accuracy > 100 m`. The watch keeps running (`enableHighAccuracy: true`), the safety-net timer still flips `loading` off so the **Atnaujinti lokaciją** retry button stays available, and once a real fix arrives `applyPosition` updates `coordinates` normally.

## Test plan
- [ ] Open the app on a phone with location services → first fix appears as before (≤ 8s) **if** GPS is good; otherwise the `Atnaujinti lokaciją` button is shown.
- [ ] Open in desktop browser with WiFi/IP geolocation enabled → no coords are applied, retry button is shown.
- [ ] Take device to actual fishing location and press a tool/weigh action → real GPS fix is recorded (not the ISP-side triangulation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)