### PR TITLE
refactor(fishing-actions): extract guards into a util, hoist type exports

### DIFF
--- a/src/components/containers/FishingActions.tsx
+++ b/src/components/containers/FishingActions.tsx
@@ -2,7 +2,13 @@ import { useContext } from 'react';
 import { useQuery } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
-import { Fishing, FishingTypeRoute, PopupContentType, slugs } from '../../utils';
+import {
+  computeFishingActionGuards,
+  Fishing,
+  FishingTypeRoute,
+  PopupContentType,
+  slugs,
+} from '../../utils';
 import api from '../../utils/api';
 import { Variant } from '../buttons/FishingLocationButton';
 import LargeButton from '../buttons/LargeButton';
@@ -34,27 +40,9 @@ const FishingActions = ({ fishing }: FishingActionsProps) => {
   );
 
   const locationType = fishing?.type;
-
   const loading = fishingWeightsLoading;
-
-  const hasFishAmount = (record?: Record<string, unknown>) =>
-    !!record && Object.values(record).some((amount) => Number(amount) > 0);
-
-  const weightOnBoatExist = hasFishAmount(fishingWeights?.preliminary);
-
-  const weightOnShoreExist = hasFishAmount(fishingWeights?.total);
-
-  const isDisabled = weightOnShoreExist;
-
-  const shoreWeighingDisabled = isDisabled || !weightOnBoatExist;
-
-  // Mirrors the server-side `assertEveryToolTypeHasFishLogged` guard
-  // (biip-zvejyba-api: any tool type weighed with `data: {}` and no
-  // sibling carries fish). Comes back on the same `fishings/weights`
-  // payload — no extra round-trip.
-  const hasUncompletedTools = !!fishingWeights?.hasUncompletedTools;
-  const finishDisabled =
-    (weightOnBoatExist && !weightOnShoreExist) || hasUncompletedTools;
+  const { fishingComplete, shoreWeighingDisabled, finishDisabled } =
+    computeFishingActionGuards(fishingWeights);
 
   return loading ? (
     <LoaderComponent />
@@ -69,7 +57,7 @@ const FishingActions = ({ fishing }: FishingActionsProps) => {
           onClick={() => {
             navigate(slugs.fishingTools(FishingTypeRoute[locationType]));
           }}
-          isDisabled={isDisabled}
+          isDisabled={fishingComplete}
         />
         <LargeButton
           variant={Variant.GHOST_WHITE}

--- a/src/utils/functions.ts
+++ b/src/utils/functions.ts
@@ -5,7 +5,14 @@ import Cookies from 'universal-cookie';
 import api from './api';
 import { ToolTypeType } from './constants';
 import { validationTexts } from './texts';
-import { Profile, ProfileId, ReactQueryError, ResponseProps, ToolsGroup } from './types';
+import {
+  FishingWeights,
+  Profile,
+  ProfileId,
+  ReactQueryError,
+  ResponseProps,
+  ToolsGroup,
+} from './types';
 const cookies = new Cookies();
 
 interface UpdateTokenProps {
@@ -13,6 +20,20 @@ interface UpdateTokenProps {
   error?: string;
   message?: string;
   refreshToken?: string;
+}
+
+export interface BuiltToolsGuards {
+  toolTypesCounts: Record<string, number>;
+  checkedToolTypesCounts: Record<string, number>;
+  withFishToolTypesCounts: Record<string, number>;
+  notCompletedToolType?: string;
+  blockReturnToolTypes: Set<string>;
+}
+
+export interface FishingActionGuards {
+  fishingComplete: boolean;
+  shoreWeighingDisabled: boolean;
+  finishDisabled: boolean;
 }
 
 export const clearCookies = () => {
@@ -214,14 +235,6 @@ export const getBuiltToolInfo = (toolsGroup: ToolsGroup) => {
   };
 };
 
-export type BuiltToolsGuards = {
-  toolTypesCounts: Record<string, number>;
-  checkedToolTypesCounts: Record<string, number>;
-  withFishToolTypesCounts: Record<string, number>;
-  notCompletedToolType?: string;
-  blockReturnToolTypes: Set<string>;
-};
-
 // Pre-computes the per-tool-type aggregates the tool-list pages need:
 // total / checked / with-fish counts, the type that's mid-checking, and the
 // types where returning the last unchecked tool would silently lose the
@@ -269,6 +282,38 @@ export const computeBuiltToolsGuards = (builtTools: any[]): BuiltToolsGuards => 
   }
 
   return { ...acc, notCompletedToolType, blockReturnToolTypes };
+};
+
+// Resolves the three `LargeButton` enable/disable states on the fishing
+// actions screen off a single `fishings/weights` payload. Centralised so
+// the rules (and their relationship to the BE guards they mirror) live
+// in one place — see the matching `assertEveryToolTypeHasFishLogged`
+// and shore-weigh logic in biip-zvejyba-api `fishings.service.ts`.
+export const computeFishingActionGuards = (
+  fishingWeights?: FishingWeights,
+): FishingActionGuards => {
+  const hasFish = (record?: Record<string, unknown>) =>
+    !!record && Object.values(record).some((amount) => Number(amount) > 0);
+
+  const hasPreliminaryFish = hasFish(fishingWeights?.preliminary);
+  const hasShoreWeighedFish = hasFish(fishingWeights?.total);
+  const hasUncompletedTools = !!fishingWeights?.hasUncompletedTools;
+
+  // Shore weighing is the terminal catch step; once it's done the
+  // fishing is effectively closed and only Baigti is left.
+  const fishingComplete = hasShoreWeighedFish;
+
+  return {
+    fishingComplete,
+    // Shore weighing requires a preliminary catch and is locked once
+    // it's been performed.
+    shoreWeighingDisabled: fishingComplete || !hasPreliminaryFish,
+    // Two server-enforced rules block Baigti:
+    // - preliminary catch must be shore-weighed
+    // - no (tool type, location) bucket left in Patikrinta-without-fish state
+    finishDisabled:
+      (hasPreliminaryFish && !hasShoreWeighedFish) || hasUncompletedTools,
+  };
 };
 
 export const getReactQueryErrorMessage = (response?: ReactQueryError) =>


### PR DESCRIPTION
## Summary

Three follow-ups to #149:

- Pull the inline boolean soup (`weightOnBoatExist`, `weightOnShoreExist`, `isDisabled`, `shoreWeighingDisabled`, `finishDisabled`) into a single `computeFishingActionGuards(fishingWeights)` helper in `src/utils/functions.ts`. The component is back to a tidy destructure + JSX.
- Rename the confusingly-named `isDisabled` to **`fishingComplete`**. It reads "is the fishing closed?" rather than "is this button disabled?", and drives both the tools card lock and the shore-weigh lock.
- Hoist `BuiltToolsGuards` / `FishingActionGuards` to the top of `utils/functions.ts` (next to the existing `UpdateTokenProps`) and switch to `interface` to match the file's convention.

## Test plan
- [ ] Open the actions screen — same three buttons, same labels.
- [ ] Patikrinta-without-fish state → Baigti disabled (no behaviour change).
- [ ] Shore-weighed state → Atidaryti (tools) and Sverti are disabled (no behaviour change).
- [ ] `tsc --noEmit` passes; no warnings about unused identifiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)