### PR TITLE
geolocation: revert 100m threshold + prefer high-accuracy initial fix (30s timeout)

### DIFF
--- a/src/components/providers/GeolocationProvider.tsx
+++ b/src/components/providers/GeolocationProvider.tsx
@@ -19,12 +19,19 @@ const WATCH_OPTIONS: PositionOptions = {
   maximumAge: 25000,
 };
 
-// Initial fast fix using whatever the device has handy (cell / wifi cache).
-// Boat-side GPS warm-ups can take 10s+, which is why ~50% of users were
-// hitting the timeout error toast on first load.
+// Initial fix — `enableHighAccuracy: true` lets the OS return the latest
+// cached GPS reading (within `maximumAge`) instead of a fresh cell/WiFi
+// triangulation that produced the 297/298/301 "all points raised up"
+// reports. 30 s covers a cold-start GNSS acquisition with AGPS over
+// cellular (5–15 s typical, occasionally up to ~25 s); indoor sessions
+// without a sky view never get a fix at any timeout. The watch runs
+// in parallel so this one-shot call is a best-effort shortcut, not a
+// gate; the `SETTLE_LOADING_TIMEOUT_MS` safety net still flips
+// `loading=false` after 15 s so the manual-entry retry button isn't
+// blocked.
 const INITIAL_FIX_OPTIONS: PositionOptions = {
-  enableHighAccuracy: false,
-  timeout: 8000,
+  enableHighAccuracy: true,
+  timeout: 30000,
   maximumAge: 60000,
 };
 

--- a/src/components/providers/GeolocationProvider.tsx
+++ b/src/components/providers/GeolocationProvider.tsx
@@ -38,15 +38,6 @@ const INITIAL_FIX_OPTIONS: PositionOptions = {
 // of meters, so 50 m is well within the same bucket).
 const MIN_COORDINATE_DELTA = 0.0005;
 
-// Reject any fix worse than this — `enableHighAccuracy: false` initial
-// fixes (cell / WiFi triangulation) can be 500–5000 m off in coastal
-// Lithuania, which is what the field audit reported as "all points
-// raised up" on the admin map. Skipping the position keeps the watch
-// running and lets a real GPS fix arrive seconds later. 100 m is well
-// inside any bar / polder / lake bucket but tight enough to make
-// triangulation fixes unusable.
-const MAX_ACCURACY_METERS = 100;
-
 // Safety net: if neither the initial fix nor the watch yields a position
 // within this window, flip `loading` to false so consumers can fall back to
 // manual location entry / the "Atnaujinti lokaciją" retry button. The watch
@@ -82,12 +73,6 @@ export const GeolocationProvider: React.FC<{ children: React.ReactNode }> = ({ c
   };
 
   const applyPosition = (position: GeolocationPosition) => {
-    // Triangulation / coarse fixes report accuracy in the high hundreds or
-    // thousands of meters. Holding onto whatever the previous (or no) fix
-    // was buys time for the high-accuracy watch to deliver a real GPS fix.
-    const accuracy = position.coords.accuracy ?? Infinity;
-    if (accuracy > MAX_ACCURACY_METERS) return;
-
     setCoordinates((prev) => {
       const next = {
         x: position.coords.longitude,

--- a/src/components/providers/GeolocationProvider.tsx
+++ b/src/components/providers/GeolocationProvider.tsx
@@ -13,26 +13,36 @@ export interface GeolocationContextProps {
 }
 
 // Continuous high-accuracy watch — used once the angler is on the water.
+// 60 s `timeout` so each watch tick waits long enough to actually pick
+// up a GNSS fix on cold start; `maximumAge` is short so the OS reuses
+// only freshly-known positions when the boat is moving.
 const WATCH_OPTIONS: PositionOptions = {
   enableHighAccuracy: true,
-  timeout: 20000,
+  timeout: 60000,
   maximumAge: 25000,
 };
 
 // Initial fix — `enableHighAccuracy: true` lets the OS return the latest
-// cached GPS reading (within `maximumAge`) instead of a fresh cell/WiFi
-// triangulation that produced the 297/298/301 "all points raised up"
-// reports. 30 s covers a cold-start GNSS acquisition with AGPS over
-// cellular (5–15 s typical, occasionally up to ~25 s); indoor sessions
-// without a sky view never get a fix at any timeout. The watch runs
-// in parallel so this one-shot call is a best-effort shortcut, not a
-// gate; the `SETTLE_LOADING_TIMEOUT_MS` safety net still flips
-// `loading=false` after 15 s so the manual-entry retry button isn't
-// blocked.
+// cached GPS reading instead of a fresh cell/WiFi triangulation (that
+// shortcut produced the 297/298/301 "all points raised up" reports).
+//
+// `maximumAge: 10000` — only reuse a cached fix when the user opened
+// the app within the last 10 s. Larger windows let the OS return a
+// position from minutes ago that may be from a completely different
+// location (angler unlocks phone at home, drives to the dock, opens
+// the app — a 60 s cache would happily hand back the home reading).
+//
+// `timeout: 60000` — covers cold-start GNSS acquisition with AGPS
+// over cellular (5–15 s typical, occasionally up to ~25 s) and adds
+// generous slack for offline/no-AGPS cold starts that need ~30–60 s.
+// The watch runs in parallel, so this one-shot call is a best-effort
+// shortcut, not a gate; the `SETTLE_LOADING_TIMEOUT_MS` safety net
+// still flips `loading=false` after 15 s so the manual-entry retry
+// button isn't blocked.
 const INITIAL_FIX_OPTIONS: PositionOptions = {
   enableHighAccuracy: true,
-  timeout: 30000,
-  maximumAge: 60000,
+  timeout: 60000,
+  maximumAge: 10000,
 };
 
 // On a moving boat the GPS can fire several times per second with


### PR DESCRIPTION
## Summary

Two related changes for the GPS provider on `revert/gps-accuracy-threshold`:

### 1) Revert the 100m accuracy threshold ([commit cf874fd](../../commit/cf874fd))

Field testing surfaced two regressions tracing back to PR #148:

- Action handlers (`FishingWeight`, `EndFishing`, `StartFishing`, `StartFishingInlandWater`, `SkipFishing`) showed both *"Dar nustatoma..."* info toast **and** *"Privalote leisti..."* error toast at once — `SETTLE_LOADING_TIMEOUT_MS` flipped `loading=false` while `coordinates` was still null because the cell/WiFi fix had been rejected. Toast cleanup landed in [#151](https://github.com/AplinkosMinisterija/biip-zvejyba-web/pull/151).
- Even with #151 the user couldn't submit anything while waiting for a true GPS fix that might never arrive on a desktop browser or indoor session.

The 100m threshold was the right *intuition* (cell/WiFi triangulation produced the 297/298/301 "all points raised up" reports), but the wrong *implementation* — it broke the everyday flow.

### 2) Prefer high-accuracy initial fix; 30s cold-start timeout ([commit ee2c8dc](../../commit/ee2c8dc))

Reverting alone takes the initial call back to `enableHighAccuracy: false` → cell/WiFi triangulation again. Instead, switch the initial one-shot to `enableHighAccuracy: true` and bump `timeout: 8000 → 30000` so cold-start GNSS acquisition with AGPS (typical 5–15 s, occasionally ~25 s) doesn't error out.

- Mobile with a recent cached GPS reading → returned instantly via `maximumAge: 60000`.
- Mobile cold start outdoor → fix within ~25 s (covered by 30 s timeout).
- Mobile indoor / desktop without GNSS → browser falls back to network sources; same worst-case behaviour as before #148.
- The watch keeps running in parallel and `SETTLE_LOADING_TIMEOUT_MS` (15 s) still flips `loading=false` so the manual-entry retry button stays available.

## Pairs with
- biip-zvejyba-web [#151](https://github.com/AplinkosMinisterija/biip-zvejyba-web/pull/151) — toast handler refactor (don't stack two toasts).

## Better fix (deferred, separate work)

Persist `position.coords.accuracy` alongside the stored geom and render a confidence circle on the admin journal map. Lets auditors judge trustworthy points vs. cell-triangulation noise without blocking the angler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)