### PR TITLE
fix(caddy): explicit Cache-Control for SPA shell + hashed assets

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -2,6 +2,26 @@
 	root * /srv
 	encode gzip
 
+	# Hashed Vite bundles in /assets/* (e.g. index-abc123.js) are
+	# content-addressed and immutable — cache them forever so repeat
+	# visits don't redownload the SPA. The hash in the filename
+	# guarantees a fresh URL whenever the bundle changes.
+	@hashedAssets path /assets/*
+	header @hashedAssets Cache-Control "public, max-age=31536000, immutable"
+
+	# Everything that decides which bundle to load (or shapes the PWA
+	# update flow) must NEVER be served from cache — otherwise a deploy
+	# leaves users on an old service worker referencing assets that no
+	# longer exist, and they're stuck on stale code until they
+	# hard-refresh.
+	@noCache {
+		path / /index.html /sw.js /registerSW.js /manifest.webmanifest
+		path /workbox-*.js
+	}
+	header @noCache Cache-Control "no-cache, no-store, must-revalidate"
+	header @noCache Pragma "no-cache"
+	header @noCache Expires "0"
+
 	try_files {path} {file} /index.html
 	file_server
 }


### PR DESCRIPTION
## Summary

The container Caddyfile served everything with default heuristic caching — no explicit `Cache-Control` headers. Browser heuristic on a long-stable `index.html` (`Date − Last-Modified` large) caches it for ~10% of that age, which on a slowly-changing branch is **hours**.

Result after a deploy: users keep loading the cached `index.html`, which points at old hashed bundles **and** the old service-worker URL. The PWA's `autoUpdate` path never fires because the browser never asks for the new `sw.js`. Users sit on stale code until a hard-refresh / cache clear — which matches the *"kodėl tas pats senas elgesys net po deploy'o"* field reports.

## Fix

Split the cache policy along the only line that actually matters for SPAs:

| Path | `Cache-Control` | Why |
|---|---|---|
| `/assets/*` (Vite hashed bundles `index-<hash>.js`) | `public, max-age=31536000, immutable` | Hash in filename guarantees a fresh URL when the bundle changes — safe to cache forever. |
| `/`, `/index.html`, `/sw.js`, `/registerSW.js`, `/manifest.webmanifest`, `/workbox-*.js` | `no-cache, no-store, must-revalidate` | Every load must reach the origin so a deploy is picked up on the next visit. |

## Test plan

- [ ] `curl -I https://staging-zvejyba.biip.lt/` returns `Cache-Control: no-cache, no-store, must-revalidate`.
- [ ] `curl -I https://staging-zvejyba.biip.lt/sw.js` returns the same.
- [ ] `curl -I https://staging-zvejyba.biip.lt/assets/index-<hash>.js` returns `Cache-Control: public, max-age=31536000, immutable`.
- [ ] After a deploy: open the app in a browser that already has the SPA cached → reload once → new bundle is fetched (verify via the bundle hash in DevTools Network).
- [ ] PWA `autoUpdate` flow: SW update detected on next visit, no hard-refresh needed.

## Follow-up (out of scope here)

Same pattern is missing in `biip-medziokle-web`, `biip-uetk-web`, `biip-zuvinimas-web`, `biip-rusys-web` (`rusys` does get a blanket `no-cache` via biip-infra, but that hurts repeat-visit performance because it strips long-cache from hashed assets too). Worth porting this granular split there in follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)