### PR TITLE
fix(geolocation): bring watchPosition back with identity-check dedupe

### DIFF
--- a/src/components/providers/GeolocationProvider.tsx
+++ b/src/components/providers/GeolocationProvider.tsx
@@ -39,25 +39,56 @@ export const GeolocationProvider: React.FC<{ children: React.ReactNode }> = ({ c
   const [coordinates, setCoordinates] = useState<Coordinates | null>(null);
   const [loading, setLoading] = useState(true);
 
+  const watchIdRef = useRef<number | null>(null);
   const loadingToastShownRef = useRef(false);
   const permissionDeniedRef = useRef(false);
 
   const applyPosition = (position: GeolocationPosition) => {
-    setCoordinates({
+    const next = {
       x: position.coords.longitude,
       y: position.coords.latitude,
+    };
+    setCoordinates((prev) => {
+      // Skip byte-identical fixes to avoid pointless re-renders. GNSS
+      // produces sub-meter drift on every tick (the trailing float
+      // digits always change), so a real GNSS fix is never byte-equal
+      // to the previous one. WiFi/cell triangulation often returns the
+      // same rounded fix repeatedly — this filters those duplicates
+      // without rejecting better fixes (no distance threshold).
+      if (prev && prev.x === next.x && prev.y === next.y) return prev;
+      return next;
     });
     setLoading(false);
     loadingToastShownRef.current = false;
   };
 
-  const handleGeolocationError = (err: GeolocationPositionError) => {
+  const handleGeolocationError = (err: GeolocationPositionError, isWatch: boolean) => {
     if (err.code === 1) {
       permissionDeniedRef.current = true;
       handleErrorToast('Nesuteikti vietos nustatymo leidimai. Patikrinkite naršyklės nustatymus.');
+      if (watchIdRef.current !== null) {
+        navigator.geolocation.clearWatch(watchIdRef.current);
+        watchIdRef.current = null;
+      }
+      setLoading(false);
+      return;
     }
-    setLoading(false);
-    loadingToastShownRef.current = false;
+    // Transient errors on the watch are fine — it keeps running and a
+    // later tick will succeed. Only settle loading on the initial fix
+    // failure so consumers can fall back to manual entry.
+    if (!isWatch) {
+      setLoading(false);
+      loadingToastShownRef.current = false;
+    }
+  };
+
+  const startWatch = () => {
+    if (watchIdRef.current !== null || permissionDeniedRef.current) return;
+    watchIdRef.current = navigator.geolocation.watchPosition(
+      applyPosition,
+      (err) => handleGeolocationError(err, true),
+      POSITION_OPTIONS,
+    );
   };
 
   const requestCurrentPosition = useCallback(() => {
@@ -78,15 +109,30 @@ export const GeolocationProvider: React.FC<{ children: React.ReactNode }> = ({ c
       handleGeolocationToast(true);
     }
 
+    // Continuous watch with the same options keeps the GPS chip warm
+    // and feeds fresh coordinates as the boat moves between spots, so
+    // the user doesn't have to mash "Atnaujinti lokaciją" before each
+    // tap. Each tick is equivalent to a fresh `getCurrentPosition`
+    // call with `maximumAge: 0`, so accuracy is identical.
+    startWatch();
+
+    // One-shot initial fix in parallel — sometimes succeeds before the
+    // watch's first tick on warm GPS.
     navigator.geolocation.getCurrentPosition(
       applyPosition,
-      handleGeolocationError,
+      (err) => handleGeolocationError(err, false),
       POSITION_OPTIONS,
     );
   }, []);
 
   useEffect(() => {
     requestCurrentPosition();
+    return () => {
+      if (watchIdRef.current !== null) {
+        navigator.geolocation.clearWatch(watchIdRef.current);
+        watchIdRef.current = null;
+      }
+    };
   }, [requestCurrentPosition]);
 
   return (


### PR DESCRIPTION
## Kontekstas

PR #154 supaprastino Provider'į pagal gps-coordinates.net, bet nuėmė `watchPosition` visam laikui. Tai sukėlė naują problemą lauke: po app'o atidarymo coords fetch'inami vieną kartą ir lieka užfiksuoti tame taške — žvejui plaukiant į kitą barą koordinatės nebeatsinaujina, ir submit'ai siunčia ne dabartinę poziciją.

Staging patikrinimas po #154 merge'o ([assets/index-Bt28hxYM.js](https://staging-zvejyba.biip.lt/assets/index-Bt28hxYM.js)) patvirtino — bundle'is turi tik vieną-kartinį `getCurrentPosition`, nėra watch'o.

## Sprendimas

Grąžinu `watchPosition` su **tom pačiom options'om** kaip ir vieno-kartinis call'as:
- `enableHighAccuracy: true`
- `maximumAge: 0`
- `timeout: 120000`

**Accuracy IDENTIŠKAS** — OS pusėje `getCurrentPosition` ir `watchPosition` naudoja tą patį Core Location / FusedLocationProvider. Tos pačios options → ta pati accuracy per fix'ą. Skirtumas tik tas, kad success callback šaudomas kontinualiai, ne vieną kartą.

## Identity-check dedupe (NE 50m threshold)

Pridedu byte-identical check'ą `setCoordinates`'e — skip'inu tik EXACT duplicate'us (`prev.x === next.x && prev.y === next.y`):

- GNSS sub-meter drift KIEKVIENAM tick'ui keičia paskutinius float skaitmenis → realus GNSS fix'as NIEKADA nebus byte-equal su praeitu → visi GNSS update'ai praeina
- WiFi/cell triangulation kartais grąžina identical apvalintus fix'us → šitie filtruojami, kad nebūtų pointless re-render'ių
- **Geresnis GNSS fix'as VISADA priimamas** — 5m accuracy ir 200m accuracy turi skirtingus float'us, tai nėra 50m threshold rejection'o

## Kodėl tai NE praeitos 50m threshold versijos atgaivinimas

Pre-#152 dizainas turėjo `MIN_COORDINATE_DELTA = 0.0005` (50m) — jis tyliai atmesdavo GNSS upgrade'us per WiFi initial fix'us. To bug'o čia NĖRA, nes identity check'as filtruoja TIK byte-equal duplicate'us, ne „arti vienas kito".

## Test plan

- [ ] Atidaryti app'ą — coords fetch'inami, toast'as „Dar nustatoma" rodomas
- [ ] Per 10-30s gauti coords, toast'as dingsta
- [ ] **Walk around / drive (key test)** — coords automatiškai atsinaujina be „Atnaujinti lokaciją" paspaudimo
- [ ] Submit event'ą — siunčia DABARTINĖS pozicijos coords, ne pradinės
- [ ] DevTools console — neturi būti pointless re-render spam'o nuo identity dedupe

🤖 Generated with [Claude Code](https://claude.com/claude-code)