### PR TITLE
fix(security): harden auth cookie attributes — secure + sameSite=lax

### DIFF
--- a/src/utils/functions.ts
+++ b/src/utils/functions.ts
@@ -15,6 +15,20 @@ import {
 } from './types';
 const cookies = new Cookies();
 
+// Cookie security baseline. Until this PR every cookie used by the app
+// (`token`, `refreshToken`, `profileId`, `module`) was stored with only
+// `{ path: '/' }` — readable to any JS on the origin and sent on every
+// cross-site navigation. `secure: true` forces TLS-only delivery (we
+// auto-skip it on http://localhost so Vite dev still works), and
+// `sameSite: 'lax'` blocks the cookie from being sent on cross-site
+// POSTs while still allowing the E-vartai redirect chain (which is a
+// top-level GET back to our origin). See security audit #C8.
+const SECURE_COOKIE_OPTS = {
+  path: '/' as const,
+  secure: typeof window !== 'undefined' && window.location.protocol === 'https:',
+  sameSite: 'lax' as const,
+};
+
 interface UpdateTokenProps {
   token?: string;
   error?: string;
@@ -136,7 +150,7 @@ export const handleSetProfile = (profiles?: Profile[], justLoggedIn: boolean = f
 
 export const handleSelectProfile = (profileId: ProfileId) => {
   if (cookies.get('profileId') == profileId) return;
-  cookies.set('profileId', `${profileId}`, { path: '/' });
+  cookies.set('profileId', `${profileId}`, SECURE_COOKIE_OPTS);
   window.location.reload();
 };
 
@@ -145,14 +159,14 @@ export const handleUpdateTokens = (data: UpdateTokenProps) => {
 
   if (token) {
     cookies.set('token', `${token}`, {
-      path: '/',
+      ...SECURE_COOKIE_OPTS,
       expires: new Date(new Date().getTime() + 60 * 60 * 24 * 1000),
     });
   }
 
   if (refreshToken) {
     cookies.set('refreshToken', `${refreshToken}`, {
-      path: '/',
+      ...SECURE_COOKIE_OPTS,
       expires: new Date(new Date().getTime() + 60 * 60 * 24 * 1000 * 30),
     });
   }


### PR DESCRIPTION
## Summary

Closes the FE half of the /cso security audit (finding **C8**). Adds `secure` + `sameSite='lax'` to every `cookies.set` call in `utils/functions.ts` via a shared `SECURE_COOKIE_OPTS` baseline.

\`secure\` is auto-skipped on \`http://localhost\` so Vite dev keeps working.

Pairs with the BE hardening PR: https://github.com/AplinkosMinisterija/biip-zvejyba-api/pull/129

## Test plan

- [x] \`tsc --noEmit\` clean
- [ ] Visual smoke after deploy:
  - login flow lands a token in cookie (DevTools → Application → Cookies shows \`Secure | SameSite=Lax\`)
  - E-vartai redirect chain still completes
  - profile switching still works (\`profileId\` cookie set + reload)
  - logout clears all 4 cookies

🤖 Generated with [Claude Code](https://claude.com/claude-code)