### PR TITLE
feat(tools): require check/weigh before returning any tool to warehouse

### DIFF
--- a/src/pages/FishingToolsEstuary.tsx
+++ b/src/pages/FishingToolsEstuary.tsx
@@ -78,7 +78,7 @@ const FishingToolsEstuary = () => {
   const currentLocation = manualLocation || location;
   const showBuildToolsButton = !!currentLocation?.id;
 
-  const { toolTypesCounts, checkedToolTypesCounts, notCompletedToolType, blockReturnToolTypes } =
+  const { toolTypesCounts, checkedToolTypesCounts, notCompletedToolType } =
     computeBuiltToolsGuards(builtTools);
 
   return (
@@ -111,11 +111,7 @@ const FishingToolsEstuary = () => {
             const showCheckButton =
               toolTypesCounts[typeKey] - (checkedToolTypesCounts?.[typeKey] || 0) > 1;
 
-            const canReturnToWarehouse = canReturnToolToWarehouse(
-              toolsGroup,
-              blockReturnToolTypes,
-              currentFishing?.id,
-            );
+            const canReturnToWarehouse = canReturnToolToWarehouse(toolsGroup);
 
             return (
               <ToolsGroupCard

--- a/src/pages/FishingToolsEstuary.tsx
+++ b/src/pages/FishingToolsEstuary.tsx
@@ -12,6 +12,7 @@ import LoaderComponent from '../components/other/LoaderComponent';
 import LocationInfo from '../components/other/LocationInfo';
 import { NotFound } from '../components/other/NotFound';
 import {
+  canReturnToolToWarehouse,
   computeBuiltToolsGuards,
   handleErrorToastFromServer,
   LocationType,
@@ -110,12 +111,11 @@ const FishingToolsEstuary = () => {
             const showCheckButton =
               toolTypesCounts[typeKey] - (checkedToolTypesCounts?.[typeKey] || 0) > 1;
 
-            // Mirror of BE `assertSiblingsHaveFishLogged` — hide the
-            // "Sugrąžinti į sandėlį" option when returning this tool would
-            // be rejected (last unchecked of a type with only empty
-            // Patikrinta siblings, no fish anywhere).
-            const canReturnToWarehouse =
-              !!toolsGroup.weightEvent || !blockReturnToolTypes.has(typeKey);
+            const canReturnToWarehouse = canReturnToolToWarehouse(
+              toolsGroup,
+              blockReturnToolTypes,
+              currentFishing?.id,
+            );
 
             return (
               <ToolsGroupCard

--- a/src/pages/FishingToolsInlandWaters.tsx
+++ b/src/pages/FishingToolsInlandWaters.tsx
@@ -12,6 +12,7 @@ import LoaderComponent from '../components/other/LoaderComponent';
 import LocationInfo from '../components/other/LocationInfo';
 import { NotFound } from '../components/other/NotFound';
 import {
+  canReturnToolToWarehouse,
   computeBuiltToolsGuards,
   handleErrorToastFromServer,
   LocationType,
@@ -111,8 +112,11 @@ const FishingTools = () => {
             const showCheckButton =
               toolTypesCounts[typeKey] - (checkedToolTypesCounts?.[typeKey] || 0) > 1;
 
-            const canReturnToWarehouse =
-              !!toolsGroup.weightEvent || !blockReturnToolTypes.has(typeKey);
+            const canReturnToWarehouse = canReturnToolToWarehouse(
+              toolsGroup,
+              blockReturnToolTypes,
+              currentFishing?.id,
+            );
 
             return (
               <ToolsGroupCard

--- a/src/pages/FishingToolsInlandWaters.tsx
+++ b/src/pages/FishingToolsInlandWaters.tsx
@@ -78,7 +78,7 @@ const FishingTools = () => {
     return <LoaderComponent />;
   }
 
-  const { toolTypesCounts, checkedToolTypesCounts, notCompletedToolType, blockReturnToolTypes } =
+  const { toolTypesCounts, checkedToolTypesCounts, notCompletedToolType } =
     computeBuiltToolsGuards(builtTools);
 
   return (
@@ -112,11 +112,7 @@ const FishingTools = () => {
             const showCheckButton =
               toolTypesCounts[typeKey] - (checkedToolTypesCounts?.[typeKey] || 0) > 1;
 
-            const canReturnToWarehouse = canReturnToolToWarehouse(
-              toolsGroup,
-              blockReturnToolTypes,
-              currentFishing?.id,
-            );
+            const canReturnToWarehouse = canReturnToolToWarehouse(toolsGroup);
 
             return (
               <ToolsGroupCard

--- a/src/pages/FishingToolsPolders.tsx
+++ b/src/pages/FishingToolsPolders.tsx
@@ -12,6 +12,7 @@ import LoaderComponent from '../components/other/LoaderComponent';
 import LocationInfo from '../components/other/LocationInfo';
 import { NotFound } from '../components/other/NotFound';
 import {
+  canReturnToolToWarehouse,
   computeBuiltToolsGuards,
   device,
   handleErrorToastFromServer,
@@ -122,8 +123,11 @@ const FishingTools = () => {
               const showCheckButton =
                 toolTypesCounts[typeKey] - (checkedToolTypesCounts?.[typeKey] || 0) > 1;
 
-              const canReturnToWarehouse =
-                !!toolsGroup.weightEvent || !blockReturnToolTypes.has(typeKey);
+              const canReturnToWarehouse = canReturnToolToWarehouse(
+                toolsGroup,
+                blockReturnToolTypes,
+                currentFishing?.id,
+              );
 
               return (
                 <ToolsGroupCard

--- a/src/pages/FishingToolsPolders.tsx
+++ b/src/pages/FishingToolsPolders.tsx
@@ -80,7 +80,7 @@ const FishingTools = () => {
     return <LoaderComponent />;
   }
 
-  const { toolTypesCounts, checkedToolTypesCounts, notCompletedToolType, blockReturnToolTypes } =
+  const { toolTypesCounts, checkedToolTypesCounts, notCompletedToolType } =
     computeBuiltToolsGuards(builtTools);
 
   return (
@@ -123,11 +123,7 @@ const FishingTools = () => {
               const showCheckButton =
                 toolTypesCounts[typeKey] - (checkedToolTypesCounts?.[typeKey] || 0) > 1;
 
-              const canReturnToWarehouse = canReturnToolToWarehouse(
-                toolsGroup,
-                blockReturnToolTypes,
-                currentFishing?.id,
-              );
+              const canReturnToWarehouse = canReturnToolToWarehouse(toolsGroup);
 
               return (
                 <ToolsGroupCard

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -11,6 +11,8 @@ export enum ServerErrors {
   FISH_ALREADY_WEIGHTED = 'Fish already weighted',
   LOCATION_NOT_FOUND = 'Location not found',
   WEIGHT_DIFFERENCE = 'Weight difference greater than 20%',
+  // Must match the BE message in biip-zvejyba-api toolsGroups.removeTools.
+  PREVIOUS_FISHING_TOOL_NOT_WEIGHTED = 'Previous fishing tool not weighted',
 }
 const mapsHost = import.meta.env.VITE_MAPS_HOST;
 

--- a/src/utils/functions.ts
+++ b/src/utils/functions.ts
@@ -308,6 +308,30 @@ export const computeBuiltToolsGuards = (builtTools: any[]): BuiltToolsGuards => 
   return { ...acc, notCompletedToolType, blockReturnToolTypes };
 };
 
+// Whether the "Sugrąžinti į sandėlį" option may be shown for a built tool.
+// Mirrors the BE `removeTools` guards in biip-zvejyba-api:
+//   1. A tool checked/weighed this session (`weightEvent`) is always returnable.
+//   2. A tool deployed in an earlier, already-ended fishing must be
+//      checked/weighed in the CURRENT session first — otherwise its catch
+//      would be lost on return (BE: "Previous fishing tool not weighted").
+//   3. Otherwise mirror `assertSiblingsHaveFishLogged` (last unchecked of a
+//      type whose siblings only got empty "Patikrinta" events).
+export const canReturnToolToWarehouse = (
+  toolsGroup: ToolsGroup,
+  blockReturnToolTypes: Set<string>,
+  currentFishingId?: number,
+): boolean => {
+  if (toolsGroup?.weightEvent) return true;
+
+  const builtFishingId = toolsGroup?.buildEvent?.fishing?.id;
+  if (currentFishingId && builtFishingId && builtFishingId !== currentFishingId) {
+    return false;
+  }
+
+  const typeKey = String(toolsGroup?.tools?.[0]?.toolType?.id);
+  return !blockReturnToolTypes.has(typeKey);
+};
+
 // Resolves the three `LargeButton` enable/disable states on the fishing
 // actions screen off a single `fishings/weights` payload. Centralised so
 // the rules (and their relationship to the BE guards they mirror) live

--- a/src/utils/functions.ts
+++ b/src/utils/functions.ts
@@ -309,27 +309,13 @@ export const computeBuiltToolsGuards = (builtTools: any[]): BuiltToolsGuards => 
 };
 
 // Whether the "Sugrąžinti į sandėlį" option may be shown for a built tool.
-// Mirrors the BE `removeTools` guards in biip-zvejyba-api:
-//   1. A tool checked/weighed this session (`weightEvent`) is always returnable.
-//   2. A tool deployed in an earlier, already-ended fishing must be
-//      checked/weighed in the CURRENT session first — otherwise its catch
-//      would be lost on return (BE: "Previous fishing tool not weighted").
-//   3. Otherwise mirror `assertSiblingsHaveFishLogged` (last unchecked of a
-//      type whose siblings only got empty "Patikrinta" events).
-export const canReturnToolToWarehouse = (
-  toolsGroup: ToolsGroup,
-  blockReturnToolTypes: Set<string>,
-  currentFishingId?: number,
-): boolean => {
-  if (toolsGroup?.weightEvent) return true;
-
-  const builtFishingId = toolsGroup?.buildEvent?.fishing?.id;
-  if (currentFishingId && builtFishingId && builtFishingId !== currentFishingId) {
-    return false;
-  }
-
-  const typeKey = String(toolsGroup?.tools?.[0]?.toolType?.id);
-  return !blockReturnToolTypes.has(typeKey);
+// Mirrors the BE `removeTools` guard in biip-zvejyba-api: a tool can only be
+// returned once it has been checked ("Patikrinta") or weighed — both write a
+// `weightEvent` scoped to the current session. This holds whether the tool was
+// set during this fishing or an earlier, already-ended one; returning an
+// unchecked net would silently lose its catch.
+export const canReturnToolToWarehouse = (toolsGroup: ToolsGroup): boolean => {
+  return !!toolsGroup?.weightEvent;
 };
 
 // Resolves the three `LargeButton` enable/disable states on the fishing

--- a/src/utils/texts.ts
+++ b/src/utils/texts.ts
@@ -26,6 +26,8 @@ export const validationTexts: { [key: string]: string } = {
     'Sužvejotos žuvys turi būti pasvertos krante, prieš užbaigiant žvejybą',
   [ServerErrors.LOCATION_NOT_FOUND]: 'Nepavyko nustatyti vandens telkinio pagal įvestas koordinates',
   [ServerErrors.FISH_ALREADY_WEIGHTED]: 'Žuvis krante jau buvo pasverta',
+  [ServerErrors.PREVIOUS_FISHING_TOOL_NOT_WEIGHTED]:
+    'Šis įrankis pastatytas ankstesnėje žvejyboje. Prieš grąžinant į sandėlį, patikrinkite arba pasverkite žuvį.',
   badFileTypes: 'Blogi failų tipai',
   fileSizesExceeded: 'Viršyti failų dydžiai',
   personalCode: 'Neteisingas asmens kodo formatas',

--- a/src/utils/texts.ts
+++ b/src/utils/texts.ts
@@ -27,7 +27,7 @@ export const validationTexts: { [key: string]: string } = {
   [ServerErrors.LOCATION_NOT_FOUND]: 'Nepavyko nustatyti vandens telkinio pagal įvestas koordinates',
   [ServerErrors.FISH_ALREADY_WEIGHTED]: 'Žuvis krante jau buvo pasverta',
   [ServerErrors.PREVIOUS_FISHING_TOOL_NOT_WEIGHTED]:
-    'Šis įrankis pastatytas ankstesnėje žvejyboje. Prieš grąžinant į sandėlį, patikrinkite arba pasverkite žuvį.',
+    'Prieš grąžinant įrankį į sandėlį, jį reikia patikrinti arba pasverti.',
   badFileTypes: 'Blogi failų tipai',
   fileSizesExceeded: 'Viršyti failų dydžiai',
   personalCode: 'Neteisingas asmens kodo formatas',

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -90,6 +90,7 @@ export interface ToolsGroupEvent {
   location: Location;
   user: User;
   tenant: Tenant;
+  fishing?: Fishing;
 }
 
 export interface FishingWeights {


### PR DESCRIPTION
## Problem

A net in the water could be returned to the warehouse ("Sugrąžinti į sandėlį") without recording its catch — silently losing the fish. Originally this was guarded only for nets left over from a **previous** (already-ended) fishing; a net built in the **current** session still showed the return button while unchecked.

The backend enforces the gate (paired API PRs **biip-zvejyba-api#133** previous-fishing + **biip-zvejyba-api#134** generalised to all tools); this PR makes the FE hide the button instead of erroring only after the click.

## Change

- **`canReturnToolToWarehouse` helper** (`src/utils/functions.ts`): a tool is returnable only once it has a `weightEvent` (checked "Patikrinta" or weighed), **regardless of which fishing it was set in**. Mirrors the generalised BE `removeTools` guard.
- Used by the **estuary / inland-waters / polders** tool screens to hide **"Sugrąžinti į sandėlį"** until the catch is recorded. An unchecked tool always keeps its weigh/check buttons (`showWeightButtons = !isCheckedTool`), so there is no dead-end: *check or weigh → return button appears*.
- **Error toast** generalised to *"Prieš grąžinant įrankį į sandėlį, jį reikia patikrinti arba pasverti."* (was previous-fishing-specific; now correct for both cases — a fallback for stale data / direct calls).
- Added `fishing` to the `ToolsGroupEvent` type so `buildEvent.fishing.id` is typed.

## Verification

- ✅ `tsc --noEmit` clean
- ✅ eslint clean on changed files
- ✅ `vite build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)