### PR TITLE
fix: žurnale slėpti grandininko filtrą freelanceriui + pervadinti į „Grandininkas"

### DIFF
--- a/src/pages/FishingJournal.tsx
+++ b/src/pages/FishingJournal.tsx
@@ -20,16 +20,17 @@ import {
   LocationType,
   slugs,
   TenantUser,
-  useAppSelector,
+  useGetCurrentProfile,
   useInfinityLoad,
 } from '../utils';
 import api from '../utils/api';
 
 const FishingJournal = () => {
-  // The "Žvejys" filter only applies under a company — a freelancer has only
-  // their own fishings. `freelancer` lives on the user, not the profile.
-  const freelancer = useAppSelector((state) => state.user.userData.freelancer);
-  const isCompany = !freelancer;
+  // The "Grandininkas" filter only applies under a company — a freelancer has
+  // only their own fishings. `freelancer` is a flag on the active PROFILE (the
+  // user has a company profile and a separate freelancer profile).
+  const currentProfile = useGetCurrentProfile();
+  const isCompany = !!currentProfile && !currentProfile.freelancer;
 
   // Both option lists are bounded → fetched once; the SelectField searches
   // them client-side, so no async select is needed.

--- a/src/utils/texts.ts
+++ b/src/utils/texts.ts
@@ -131,7 +131,7 @@ export const journalTableFilters = {
   type: 'Žvejybos vieta',
   createdFrom: 'Žvejybos sukūrimo data nuo',
   createdTo: 'Žvejybos sukūrimo data iki',
-  person: 'Žvejys',
+  person: 'Grandininkas',
   location: 'Vandens telkinys / polderis',
 };
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -45,6 +45,7 @@ export interface Profile {
   email?: string;
   role: RoleTypes;
   isInvestigator: boolean;
+  freelancer: boolean;
   phone: string;
 }
 


### PR DESCRIPTION
Follow-up po #158.

**Bug:** freelanceriui rodėsi (tuščias) „Žvejys" filtras. `freelancer` yra **profilio** laukas (naudotojas turi įmonės profilį IR atskirą freelancer profilį), o ne `userData` — tad `userData.freelancer` buvo `undefined` → `isCompany` visada `true` → filtras rodėsi visiems.

**Pataisa:**
- `isCompany = !!currentProfile && !currentProfile.freelancer` (per `useGetCurrentProfile`); pridėtas `freelancer` į `Profile` tipą.
- Filtro pavadinimas „Žvejys" → **„Grandininkas"** (toks terminas naudojamas žvejybos detalės puslapyje; admin'e paliekam „Žvejys" — ten nenaudojamas).

`tsc` + `eslint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)