### PR TITLE
ci: Playwright login e2e tests as a merge gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
     name: E2E tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,36 @@ jobs:
         with:
           environment: test
           push: false
+
+  e2e:
+    name: E2E tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: yarn playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        run: yarn test:e2e
+        env:
+          E2E_USER_EMAIL: ${{ secrets.E2E_USER_EMAIL }}
+          E2E_USER_PASSWORD: ${{ secrets.E2E_USER_PASSWORD }}
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ dist
 .idea
 
 eslint-results.sarif
+# Playwright
+test-results/
+playwright-report/

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "start": "vite --host",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@aplinkosministerija/design-system": "^1.2.34",
@@ -37,6 +39,7 @@
   "devDependencies": {
     "@aplinkosministerija/biip-prettier-config": "^1.1.0",
     "@aplinkosministerija/eslint-config-biip-react": "^1.0.0",
+    "@playwright/test": "^1.61.1",
     "@types/lodash": "^4.14.200",
     "@types/react": "^18.2.15",
     "@types/react-datepicker": "^4.19.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// E2E tests run the frontend from THIS branch (Vite dev server started below)
+// against a real backend. /api requests are proxied to VITE_PROXY_URL
+// (vite.config.ts), so the tests exercise the same code path as production.
+const BASE_URL = 'http://localhost:5173';
+const API_PROXY_URL = process.env.VITE_PROXY_URL || 'https://staging-zvejyba.biip.lt/api';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'html',
+  use: {
+    baseURL: BASE_URL,
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: 'yarn start',
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: {
+      VITE_PROXY_URL: API_PROXY_URL,
+    },
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+});

--- a/tests/e2e/login.spec.ts
+++ b/tests/e2e/login.spec.ts
@@ -1,0 +1,127 @@
+import { expect, Page, test } from '@playwright/test';
+
+const LOGIN_PATH = '/prisijungimas';
+
+// Real staging credentials come from CI secrets; the happy-path and
+// wrong-password tests are skipped when they are not provided (e.g. fork PRs).
+const E2E_USER_EMAIL = process.env.E2E_USER_EMAIL;
+const E2E_USER_PASSWORD = process.env.E2E_USER_PASSWORD;
+const hasCredentials = !!E2E_USER_EMAIL && !!E2E_USER_PASSWORD;
+
+const texts = {
+  eGate: 'Prisijungti per el. valdžios vartus',
+  loginWithPassword: 'Prisijungti su slaptažodžiu',
+  login: 'Prisijungti',
+  required: 'Privalomas laukelis',
+  // KNOWN BUG: rejected logins should show the specific messages from
+  // texts.ts ('Blogas elektroninis paštas arba slaptažodis'), but
+  // getReactQueryErrorMessage (functions.ts) resolves data.type first
+  // ('WRONG_PASSWORD') while the message map is keyed by message strings
+  // ('Wrong password.'), so the generic fallback renders instead. Tighten
+  // the two assertions below to the specific texts once that is fixed.
+  loginRejected: 'Įvyko nenumatyta klaida, prašome pabandyti vėliau',
+};
+
+// The login page shows only the eGate option at first — the email/password
+// form is revealed by the "Prisijungti su slaptažodžiu" button.
+async function openPasswordLogin(page: Page) {
+  await page.goto(LOGIN_PATH);
+  await page.getByRole('button', { name: texts.loginWithPassword }).click();
+  await expect(page.locator('input[type="email"]')).toBeVisible();
+}
+
+// Inputs have no label association or name attribute, so target them by type.
+function emailInput(page: Page) {
+  return page.locator('input[type="email"]');
+}
+
+function passwordInput(page: Page) {
+  return page.locator('input[type="password"]');
+}
+
+function submitButton(page: Page) {
+  return page.getByRole('button', { name: texts.login, exact: true });
+}
+
+function trackLoginRequests(page: Page) {
+  const requests: string[] = [];
+  page.on('request', (request) => {
+    if (request.url().includes('/auth/login')) {
+      requests.push(request.url());
+    }
+  });
+  return requests;
+}
+
+test.describe('Login page', () => {
+  test('shows both login options (eGate and password)', async ({ page }) => {
+    await page.goto(LOGIN_PATH);
+
+    await expect(page.getByRole('button', { name: texts.eGate })).toBeVisible();
+    await expect(page.getByRole('button', { name: texts.loginWithPassword })).toBeVisible();
+  });
+
+  test('empty submit shows required-field errors and sends no request', async ({ page }) => {
+    await openPasswordLogin(page);
+    const loginRequests = trackLoginRequests(page);
+
+    await submitButton(page).click();
+
+    await expect(page.getByText(texts.required)).toHaveCount(2);
+    expect(loginRequests).toHaveLength(0);
+    await expect(page).toHaveURL(new RegExp(LOGIN_PATH));
+  });
+
+  test('invalid email format is blocked before reaching the API', async ({ page }) => {
+    await openPasswordLogin(page);
+    const loginRequests = trackLoginRequests(page);
+
+    await emailInput(page).fill('netinkamas-pastas');
+    await passwordInput(page).fill('betkoks-slaptazodis');
+    await submitButton(page).click();
+
+    // Either native email validation or the Yup schema stops the submit —
+    // the essential invariant is that no login request leaves the browser.
+    await expect(page).toHaveURL(new RegExp(LOGIN_PATH));
+    expect(loginRequests).toHaveLength(0);
+  });
+
+  test('unknown email is rejected with a visible error', async ({ page }) => {
+    await openPasswordLogin(page);
+
+    await emailInput(page).fill('e2e-neegzistuojantis-naudotojas@biip.lt');
+    await passwordInput(page).fill('BetKoksSlaptazodis1!');
+    await submitButton(page).click();
+
+    await expect(page.getByText(texts.loginRejected)).toBeVisible({ timeout: 15_000 });
+    await expect(page).toHaveURL(new RegExp(LOGIN_PATH));
+  });
+
+  test('wrong password is rejected with a visible error', async ({ page }) => {
+    test.skip(!hasCredentials, 'E2E_USER_EMAIL / E2E_USER_PASSWORD are not set');
+    await openPasswordLogin(page);
+
+    await emailInput(page).fill(E2E_USER_EMAIL!);
+    await passwordInput(page).fill('TyciaBlogasSlaptazodis1!');
+    await submitButton(page).click();
+
+    await expect(page.getByText(texts.loginRejected)).toBeVisible({ timeout: 15_000 });
+    await expect(page).toHaveURL(new RegExp(LOGIN_PATH));
+  });
+
+  test('valid credentials log the user in', async ({ page }) => {
+    test.skip(!hasCredentials, 'E2E_USER_EMAIL / E2E_USER_PASSWORD are not set');
+    await openPasswordLogin(page);
+
+    await emailInput(page).fill(E2E_USER_EMAIL!);
+    await passwordInput(page).fill(E2E_USER_PASSWORD!);
+    await submitButton(page).click();
+
+    // A fresh login lands on profile selection (/profiliai) or, with a
+    // remembered profile, straight on /zvejyba.
+    await page.waitForURL(/\/(profiliai|zvejyba)/, { timeout: 20_000 });
+
+    const cookies = await page.context().cookies();
+    expect(cookies.find((cookie) => cookie.name === 'token')?.value).toBeTruthy();
+  });
+});

--- a/tests/e2e/login.spec.ts
+++ b/tests/e2e/login.spec.ts
@@ -86,26 +86,31 @@ test.describe('Login page', () => {
     expect(loginRequests).toHaveLength(0);
   });
 
-  test('unknown email is rejected with a visible error', async ({ page }) => {
+  test('rejected login shows a visible error', async ({ page }) => {
     await openPasswordLogin(page);
 
-    await emailInput(page).fill('e2e-neegzistuojantis-naudotojas@biip.lt');
-    await passwordInput(page).fill('BetKoksSlaptazodis1!');
-    await submitButton(page).click();
+    // Mocked with the exact staging payload (staging auth returns
+    // WRONG_PASSWORD for unknown emails too) so this required check never
+    // depends on staging uptime and burns no failed attempts on the real
+    // e2e account — only the happy-path test talks to the live backend.
+    await page.route('**/auth/login', (route) =>
+      route.fulfill({
+        status: 400,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          name: 'AuthError',
+          message: 'Wrong password.',
+          code: 400,
+          type: 'WRONG_PASSWORD',
+        }),
+      }),
+    );
 
-    await expect(page.getByText(texts.loginRejected)).toBeVisible({ timeout: 15_000 });
-    await expect(page).toHaveURL(new RegExp(LOGIN_PATH));
-  });
-
-  test('wrong password is rejected with a visible error', async ({ page }) => {
-    test.skip(!hasCredentials, 'E2E_USER_EMAIL / E2E_USER_PASSWORD are not set');
-    await openPasswordLogin(page);
-
-    await emailInput(page).fill(E2E_USER_EMAIL!);
+    await emailInput(page).fill('e2e-testas@biip.lt');
     await passwordInput(page).fill('TyciaBlogasSlaptazodis1!');
     await submitButton(page).click();
 
-    await expect(page.getByText(texts.loginRejected)).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText(texts.loginRejected)).toBeVisible();
     await expect(page).toHaveURL(new RegExp(LOGIN_PATH));
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1467,6 +1467,13 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@playwright/test@^1.61.1":
+  version "1.61.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.61.1.tgz#48568dc22af7819e55fa5e8e3bc79b7e6a3e6675"
+  integrity sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==
+  dependencies:
+    playwright "1.61.1"
+
 "@popperjs/core@^2.11.8", "@popperjs/core@^2.9.2":
   version "2.11.8"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
@@ -3112,6 +3119,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
@@ -4064,6 +4076,20 @@ picomatch@^2.2.2, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
+playwright-core@1.61.1:
+  version "1.61.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.61.1.tgz#3c99841307efbbabc9d724c41a88c914705d15fc"
+  integrity sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==
+
+playwright@1.61.1:
+  version "1.61.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.61.1.tgz#d8c0c06eb93c28981afc747bace453bdbd5018bc"
+  integrity sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==
+  dependencies:
+    playwright-core "1.61.1"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 pmtiles@^3.0.6:
   version "3.2.1"


### PR DESCRIPTION
## What

Playwright e2e tests for the login form, wired into CI as a new **E2E tests** job on every PR. The suite starts the branch's own frontend (Vite dev server) and proxies `/api` to the staging backend, so it exercises the real login flow end to end:

- both login options (eGate + password) render
- empty submit shows `Privalomas laukelis` on both fields and sends no request
- invalid email format never reaches the API
- rejected login shows a visible error and stays on `/prisijungimas` (backend mocked with the exact staging `WRONG_PASSWORD` payload, so this required check never depends on staging uptime)
- valid credentials log in and set the `token` cookie — the only test that talks to the live staging backend

Run locally with `yarn test:e2e` (or `yarn test:e2e:ui`).

## Notes

- **Secrets:** the happy-path case needs repo secrets `E2E_USER_EMAIL` / `E2E_USER_PASSWORD` (a dedicated staging test user). Until they are set — and on fork PRs, which never see secrets — it skips gracefully; the other four tests still gate.
- **To make this an actual merge gate**, after merging add `E2E tests` to the required status checks next to `Validate if docker image builds`.
- **Bug found while writing this:** rejected logins always show the generic `Įvyko nenumatyta klaida, prašome pabandyti vėliau` instead of `Blogas elektroninis paštas arba slaptažodis`. `getReactQueryErrorMessage` (`src/utils/functions.ts`) resolves `data.type` first (`WRONG_PASSWORD`), but the message map in `src/utils/texts.ts` is keyed by message strings (`Wrong password.`), so the lookup always misses. (Staging auth also returns `WRONG_PASSWORD` for unknown emails — anti-enumeration — so the `USER_NOT_FOUND` text is unreachable.) The rejection test pins the current behaviour with a comment to tighten it once this is fixed (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)